### PR TITLE
Corrección en ruta de vista - Nuevo front

### DIFF
--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -962,7 +962,7 @@
 
         <ui:include src="../../comunicacion/Editcomunicaciondesdeagenda.xhtml"/>
 
-        <ui:include src="../../eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial_desdeagenda.xhtml"/>
+        <ui:include src="../../eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml"/>
 
         <ui:include src="../../eventoDeCausaJudicial/Edit_desdeagenda.xhtml"/>
 


### PR DESCRIPTION
se cambio la ruta en uno de los include ya que en la versión anterior se había corregido el camelcase entonces al no encontrar la vista con el nuevo nombre se rompía.