### PR TITLE
Add Impuesto a las Ganancias option to judicial expediente type

### DIFF
--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -89,6 +89,7 @@
                                         <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
                                         <f:selectItem itemLabel="Otros" itemValue="Otros" />
                                         <f:selectItem itemLabel="Provincia" itemValue="Provincia" />
+                                        <f:selectItem itemLabel="Impuesto a las Ganancias" itemValue="Impuesto a las Ganancias" />
                                 </p:selectOneMenu>
                             </h:panelGrid>
                             <h:panelGrid columns="2" cellspacing="5">

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -193,6 +193,7 @@
                                     <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
                                     <f:selectItem itemLabel="Otros" itemValue="Otros" />
                                     <f:selectItem itemLabel="Provincia" itemValue="Provincia" />
+                                    <f:selectItem itemLabel="Impuesto a las Ganancias" itemValue="Impuesto a las Ganancias" />
 
                                     <p:ajax event="change" update="confirmdialog" oncomplete="PF('confirm').show()" />
                                 </p:selectOneMenu>

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -197,6 +197,7 @@
                                     <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
                                     <f:selectItem itemLabel="Otros" itemValue="Otros" />
                                     <f:selectItem itemLabel="Provincia" itemValue="Provincia" />
+                                    <f:selectItem itemLabel="Impuesto a las Ganancias" itemValue="Impuesto a las Ganancias" />
 
                                     <p:ajax event="change" update="confirmdialog" oncomplete="PF('confirm').show()" />
                                 </p:selectOneMenu>


### PR DESCRIPTION
## Summary
- add the "Impuesto a las Ganancias" choice to the Tipo selector on judicial expediente creation and edit screens
- ensure the agenda edit view exposes the same new option for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfe5f2ca20832787c204533c2893da