### PR TITLE
Limit Paula Alvarez reassignment scope

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
@@ -130,7 +130,7 @@ public class AgendaController implements Serializable {
             "Mateo Novau", "Carla Juez", "Natali D Agostino", "Maria Jose Alaye",
             "Liliana Romero", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
             "Pilar Boglione", "Juan Cuello"));
-        
+
         lideresEmpleadosMap.put("María Emilia Campos", Arrays.asList(
             "Mateo Francisco Alvarez", "Paula Alvarez", "Paola Maldonado", "Ayelen Brizzio",
             "Mateo Novau", "Carla Juez", "Natali D Agostino", "Maria Jose Alaye",
@@ -138,8 +138,8 @@ public class AgendaController implements Serializable {
             "Pilar Boglione"));
 
         lideresEmpleadosMap.put("Paula Alvarez", Arrays.asList(
-            "Mateo Novau", "Natali D Agostino", "Maria Jose Alaye", 
-            "Liliana Romero", "Pilar Boglione"));
+            "Mateo Novau", "Natali D Agostino", "Catalina Povarchik",
+            "Pilar Boglione"));
 
         lideresEmpleadosMap.put("Paola Maldonado", Arrays.asList(
             "Carla Juez", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
@@ -1129,7 +1129,7 @@ public class AgendaController implements Serializable {
             "Liliana Romero", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
             "Pilar Boglione", "juan cuello"});
         lideresEmpleadosMap.put("Paula Alvarez", new String[]{
-            "Mateo Novau", "Natali D Agostino", "Liliana Romero", "Pilar Boglione"});
+            "Mateo Novau", "Natali D Agostino", "Catalina Povarchik", "Pilar Boglione"});
         lideresEmpleadosMap.put("Paola Maldonado", new String[]{
             "Carla Juez", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
             "Maria Jose Alaye"});

--- a/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
@@ -501,8 +501,8 @@ public class TurnoController implements Serializable {
         "Liliana Romero", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
         "Pilar Boglione"});
     lideresEmpleadosMap.put("Paula Alvarez", new String[]{
-        "Mateo Novau", "Natali D Agostino", "Maria Jose Alaye", 
-        "Liliana Romero", "Pilar Boglione"});
+        "Mateo Novau", "Natali D Agostino", "Catalina Povarchik",
+        "Pilar Boglione"});
     lideresEmpleadosMap.put("Paola Maldonado", new String[]{
         "Carla Juez", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
         "Maria Jose Alaye"});


### PR DESCRIPTION
## Summary
- restore Maria Jose Alaye and Liliana Romero to the shared leader employee lists while keeping Catalina Povarchik only under Paula Alvarez
- mirror the corrected employee assignments in both AgendaController and TurnoController maps used for lookups

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfee380bd48327bf3170cbb911ae83