### PR TITLE
Limit Paola Maldonado team updates

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
@@ -130,7 +130,7 @@ public class AgendaController implements Serializable {
             "Mateo Novau", "Carla Juez", "Natali D Agostino", "Maria Jose Alaye",
             "Liliana Romero", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
             "Pilar Boglione", "Juan Cuello"));
-        
+
         lideresEmpleadosMap.put("María Emilia Campos", Arrays.asList(
             "Mateo Francisco Alvarez", "Paula Alvarez", "Paola Maldonado", "Ayelen Brizzio",
             "Mateo Novau", "Carla Juez", "Natali D Agostino", "Maria Jose Alaye",
@@ -142,8 +142,8 @@ public class AgendaController implements Serializable {
             "Liliana Romero", "Pilar Boglione"));
 
         lideresEmpleadosMap.put("Paola Maldonado", Arrays.asList(
-            "Carla Juez", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
-            "Maria Jose Alaye"));
+            "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo", "Maria Jose Alaye",
+            "Catalina Povarchik", "María Paz Bolinaga"));
 
         lideresEmpleadosMap.put("Ayelen Brizzio", Arrays.asList(
             "Mateo Novau"));
@@ -1131,8 +1131,8 @@ public class AgendaController implements Serializable {
         lideresEmpleadosMap.put("Paula Alvarez", new String[]{
             "Mateo Novau", "Natali D Agostino", "Liliana Romero", "Pilar Boglione"});
         lideresEmpleadosMap.put("Paola Maldonado", new String[]{
-            "Carla Juez", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
-            "Maria Jose Alaye"});
+            "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo", "Maria Jose Alaye",
+            "Catalina Povarchik", "María Paz Bolinaga"});
         lideresEmpleadosMap.put("Ayelen Brizzio", new String[]{
             "Mateo Novau", "Natali D Agostino",});
         

--- a/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
@@ -501,11 +501,11 @@ public class TurnoController implements Serializable {
         "Liliana Romero", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
         "Pilar Boglione"});
     lideresEmpleadosMap.put("Paula Alvarez", new String[]{
-        "Mateo Novau", "Natali D Agostino", "Maria Jose Alaye", 
+        "Mateo Novau", "Natali D Agostino", "Maria Jose Alaye",
         "Liliana Romero", "Pilar Boglione"});
     lideresEmpleadosMap.put("Paola Maldonado", new String[]{
-        "Carla Juez", "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo",
-        "Maria Jose Alaye"});
+        "Ezequiel Brener", "Camila A Ruiz Diaz", "Amparo Alanis Toledo", "Maria Jose Alaye",
+        "Catalina Povarchik", "María Paz Bolinaga"});
     lideresEmpleadosMap.put("Ayelen Brizzio", new String[]{
         "Mateo Novau"});
     


### PR DESCRIPTION
## Summary
- restore Carla Juez to the leader/employee mappings for every leader except Paola Maldonado
- keep Catalina Povarchik and María Paz Bolinaga only in Paola Maldonado's team within both agenda and turno controllers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfefd8c4b88327b27210668e8556f8