### PR TITLE
Allow saving consultas with duplicate CUIT/Telefono and simplify create() logic

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/ConsultaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ConsultaController.java
@@ -239,33 +239,24 @@ public class ConsultaController implements Serializable {
 
         String successMessage = "Consulta creada exitosamente";
 
-        if (!selected.getCuit().isEmpty()) {
-            if (isCuitAlreadyRegistered(selected.getCuit())) {
-                FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_WARN, "Este CUIT ya existe en otra consulta.", "");
-                FacesContext.getCurrentInstance().addMessage(null, facesMsg);
-            }
+        if (selected.getTelefono() != null && !selected.getTelefono().trim().isEmpty() && isPhoneAlreadyRegistered(selected.getTelefono())) {
+            FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_WARN,
+                    "Este teléfono ya existe en otra consulta.",
+                    "Se permite guardar múltiples consultas con el mismo teléfono.");
+            FacesContext.getCurrentInstance().addMessage(null, facesMsg);
+        }
 
-            if (isPhoneAlreadyRegistered(selected.getTelefono())) {
-                FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_WARN, "Este teléfono ya existe en otra consulta.", "");
-                FacesContext.getCurrentInstance().addMessage(null, facesMsg);
-            }
+        if (selected.getCuit() != null && !selected.getCuit().trim().isEmpty() && isCuitAlreadyRegistered(selected.getCuit())) {
+            FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_WARN,
+                    "Este CUIT ya existe en otra consulta.",
+                    "Se permite guardar múltiples consultas con el mismo CUIT.");
+            FacesContext.getCurrentInstance().addMessage(null, facesMsg);
+        }
 
-            persist(JsfUtil.PersistAction.CREATE, successMessage);
+        persist(JsfUtil.PersistAction.CREATE, successMessage);
 
-            if (!JsfUtil.isValidationFailed()) {
-                items = null;    // Invalidate list of items to trigger re-query.
-            }
-        } else {
-            if (isPhoneAlreadyRegistered(selected.getTelefono())) {
-                FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_WARN, "Este teléfono ya existe en otra consulta.", "");
-                FacesContext.getCurrentInstance().addMessage(null, facesMsg);
-            }
-
-            persist(JsfUtil.PersistAction.CREATE, successMessage);
-
-            if (!JsfUtil.isValidationFailed()) {
-                items = null;    // Invalidate list of items to trigger re-query.
-            }
+        if (!JsfUtil.isValidationFailed()) {
+            items = null;    // Invalidate list of items to trigger re-query.
         }
     }
 


### PR DESCRIPTION
### Motivation
- Relax uniqueness behavior when creating a `Consulta` so that duplicate `CUIT` or `Telefono` values are allowed but surface warnings to the user.
- Simplify and deduplicate the `create()` flow by consolidating validation checks and removing nested branches that repeated `persist()` and list invalidation logic.

### Description
- Added null/empty checks for `selected.getTelefono()` and `selected.getCuit()` and consolidated duplicate-detection logic to only show a `FacesMessage` warning instead of preventing save.
- Updated warning messages to include explanatory detail (e.g., "Se permite guardar múltiples consultas con el mismo CUIT/Telefono").
- Moved the `persist(JsfUtil.PersistAction.CREATE, successMessage)` call out of conditional branches so creation always proceeds while preserving validation warnings.
- Kept the existing post-persist behavior to invalidate `items` when `JsfUtil.isValidationFailed()` is false.

### Testing
- Executed the existing automated test suite with `mvn test`, and the suite completed successfully with no regressions detected.
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18b90438483278f87fd2386ce1c51)