### PR TITLE
Add predefined agenda description suggestions and UI selector

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
@@ -78,6 +78,56 @@ public class AgendaController implements Serializable {
     private static final String SI = "Si";
     private static final String NO = "No";
     private static final String ESTA_PERSONA_PARA_ESTE_DIA_YA_TIENE_40_AGENDAS = "Esta persona para este día ya tiene 40 o más agendas ";
+    private static final List<String> SUGERENCIAS_DESCRIPCION_AGENDA = Arrays.asList(
+        "Subir dda y documental  + agendar en consecuencia + cargar datos en sistema en caso de que no estén+ pedir dinero aportes si no tenemos",
+        "Verificar si recibieron en MDE y resortearon JF sino para reclamar",
+        "Hacer oficio PTN",
+        "Anotar que tuvieron por acompañado el poder, y por ratificado lo actuado. Cargar en el sistema si no está.",
+        "Verificar si volvió con dictamen fiscal y JF dictó primer decreto de traslado de la demanda sino para reclamar.",
+        "Hacer deox notificando primer decreto con copia dda y documental + agendar 60 DÍAS HÁBILES + cargar fechas judiciales (dda fecha de envío mail + este trasaldo)+ datos si no están en el sistema",
+        "Verificar si ANSES contestó demanda sino solicitar decaimiento y pasen autos a despacho.",
+        "Verificar si se encuentra toda la prueba diligenciada, acompañar ADP y solicitar clausura, y revisar que esté poder ok, sino para gestionar.",
+        "Verificar si manifestaron algo del pedido de vista de solicitud clausura sino solicitar pase a fallo.",
+        "Verificar si volvió con dictamen fiscal y pasaron autos a despacho sino reclamar.",
+        "Verificar si perito presentó planilla (lo emplazaron a hacerlo dentro de los 10 días) sino ver si contactamos o agendar para pedir emplazamiento.",
+        "Verificar si perito Villarragut compareció (lo emplazaron a hacerlo dentro de los días) sino ver si contactamos o agendar para pedir emplazamiento.",
+        "Anotar que tuvieron por decaido el derecho de anses y que esta ratificado poder y cargar en el sistema si no llega a estar",
+        "Verificar si tuvimos novedades de sentencia de primera instancia sino para empezar a reclamar. Autos",
+        "Cargar fecha judicial",
+        "Anotar a listado de cúmplase.",
+        "Avisar a Sr. que ordenaron cumplimiento y pasos a seguir.",
+        "Revisar liquidación del Sr. para verificar si procedió reajuste automático. Cúmplase",
+        "Hacer escrito solicitando oficio AFIP para que habilite liquidación mediante ley 26970 acompañar captura de pantalla para demostrar que no está la opción.",
+        "Verificar si otorgaron turno sino solicitar emplazamiento.",
+        "Ordenaron cúmplase. Hacer escrito solicita apertura cuenta y certificación honorarios.",
+        "Verificar si otorgaron turno sino para reclamar en ANSES.",
+        "Hacer bluecorp para ejecución + agendar para hacer + a Pao para verificar",
+        "Empezar con medidas preparatorias de ejecución. Descargar liquidaciones, localizar administrativo+ agendar a Pao para hacer formulario cerca de la fecha en que se vence plazo",
+        "Verificar si otorgaron turno sino cuantificar las astreintes ya ordenadas pedir el aumento y nuevo emplazamiento",
+        "Verificar si otorgaron turno sino solicitar nuevo emplazamiento y astreintes.",
+        "Hoy se vence plazo cumplimiento ver si esta encaminado todo para presentar ejecución",
+        "Avisar al Sr. que presentamos ejecución, pasos a seguir y anotar en comunicaciones",
+        "Verificar si salió auto de aprobación de planilla sino ver si empezamos a reclamar.",
+        "Verificar si salió auto de ejecución sino ver si empezamos a reclamar.",
+        "Verificar si ANSES impugnó planilla sino solicitar aprueben y pase a resolver.",
+        "Contestar impugnación",
+        "Verificar si ANSES apeló sentencia de ejecución sino agendar a los 30 días para solicitar embargo",
+        "Avisar que salió sentencia de ejecución, explicar pasos a seguir, pedir CBU y anotar en comunicaciones.",
+        "Anotar que salió sentencia ejecución y regularon honorarios en UMAS",
+        "Verificar si ANSES cumplió sino solicitar embargo.",
+        "Verificar si se hizo efectiva transferencia, denunciar cobro y actualizar deuda.",
+        "Avisar a Sr. que ordenaron transferencia, coordinar por honorarios + agendar",
+        "Verificar si se hizo efectivo embargo sino para reclamar.",
+        "Verificar si AFIP presentó planilla rectificada sino solicitar astreintes.",
+        "Hacer apelación.",
+        "Avisar a cliente que salió sentencia de primera instancia favorable pero debemos esperar si ANSES apela + explicar pasos a seguir + anotar en comunicaciones.",
+        "Avisar a cliente que salió sentencia de primera instancia, pero debemos apelar por algunos complementos que no hicieron lugar + explicar pasos a seguir + anotar en comunicaciones.",
+        "Anotar que salió sentencia de primera instancia, impusieron costas a ANSES y difirieron regulación",
+        "Hacer cálculo de días corridos desde presentación de dda a sentencia.",
+        "Anotar que ya tenemos CBU cuenta.",
+        "Verificar si ANSES apeló sino solicitar certifiquen sentencia firme y ordenen cumplimiento.",
+        "Verificar si ya recibieron Expdte. en JF y dictaron cumplimiento sino para reclamar"
+    );
 
     private Agenda selected;
     
@@ -109,6 +159,7 @@ public class AgendaController implements Serializable {
     private List<Agenda> selectedItems;
 
     private String tipoDeAgendaMasiva;
+    private String descripcionPredeterminada;
     
     // Mapa de líderes a sus respectivos empleados
     private Map<String, List<String>> lideresEmpleadosMap;
@@ -341,6 +392,7 @@ public class AgendaController implements Serializable {
     public Agenda prepareCreate() {
         selected = new Agenda();
         selected.setRealizado("No");
+        descripcionPredeterminada = null;
         initializeEmbeddableKey();
         return selected;
     }
@@ -376,6 +428,7 @@ public class AgendaController implements Serializable {
     public Agenda prepareCreateActividad() {
         selectedActividad = new Agenda();
         selectedActividad.setRealizado("No");
+        descripcionPredeterminada = null;
         initializeEmbeddableKey();
         return selectedActividad;
     }
@@ -418,6 +471,7 @@ public class AgendaController implements Serializable {
         selectedParaCrearUnaNueva.setRealizado("No");
         selectedParaCrearUnaNueva.setResponsable(agendaAnterior.getResponsable());
         selectedParaCrearUnaNueva.setPrioridad(agendaAnterior.getPrioridad());
+        descripcionPredeterminada = null;
 
         initializeEmbeddableKey();
         return selectedParaCrearUnaNueva;
@@ -426,8 +480,39 @@ public class AgendaController implements Serializable {
     public Agenda prepareCreateConApellidoYNombre(String nombreYapellido) {
         selected = new Agenda();
         selected.setNombre(nombreYapellido);
+        descripcionPredeterminada = null;
         initializeEmbeddableKey();
         return selected;
+    }
+
+    public List<String> getSugerenciasDescripcionAgenda() {
+        return SUGERENCIAS_DESCRIPCION_AGENDA;
+    }
+
+    public String getDescripcionPredeterminada() {
+        return descripcionPredeterminada;
+    }
+
+    public void setDescripcionPredeterminada(String descripcionPredeterminada) {
+        this.descripcionPredeterminada = descripcionPredeterminada;
+    }
+
+    public void aplicarDescripcionPredeterminada() {
+        if (selected != null && descripcionPredeterminada != null && !descripcionPredeterminada.trim().isEmpty()) {
+            selected.setDescripcion(descripcionPredeterminada);
+        }
+    }
+
+    public void aplicarDescripcionPredeterminadaActividad() {
+        if (selectedActividad != null && descripcionPredeterminada != null && !descripcionPredeterminada.trim().isEmpty()) {
+            selectedActividad.setDescripcion(descripcionPredeterminada);
+        }
+    }
+
+    public void aplicarDescripcionPredeterminadaReagendar() {
+        if (selectedParaCrearUnaNueva != null && descripcionPredeterminada != null && !descripcionPredeterminada.trim().isEmpty()) {
+            selectedParaCrearUnaNueva.setDescripcion(descripcionPredeterminada);
+        }
     }
     
 
@@ -510,6 +595,7 @@ public class AgendaController implements Serializable {
             persist(PersistAction.CREATE, ResourceBundle.getBundle("/Bundle").getString("AgendaCreated"));
             if (!JsfUtil.isValidationFailed()) {
                 items = null;    // Invalidate list of items to trigger re-query.
+                prepareCreate();
             }
         }
     }
@@ -1067,65 +1153,14 @@ public class AgendaController implements Serializable {
     }
 
     public List<String> completeDescripcionAgenda(String query) {
-        List<String> sugerenciasManuales = Arrays.asList(
-        "Subir dda y documental  + agendar en consecuencia + cargar datos en sistema en caso de que no estén+ pedir dinero aportes si no tenemos",
-        "Verificar si recibieron en MDE y resortearon JF sino para reclamar",
-        "Hacer oficio PTN",
-        "Anotar que tuvieron por acompañado el poder, y por ratificado lo actuado. Cargar en el sistema si no está.",
-        "Verificar si volvió con dictamen fiscal y JF dictó primer decreto de traslado de la demanda sino para reclamar.",
-        "Hacer deox notificando primer decreto con copia dda y documental + agendar 60 DÍAS HÁBILES + cargar fechas judiciales (dda fecha de envío mail + este trasaldo)+ datos si no están en el sistema",
-        "Verificar si ANSES contestó demanda sino solicitar decaimiento y pasen autos a despacho.",
-        "Verificar si se encuentra toda la prueba diligenciada, acompañar ADP y solicitar clausura, y revisar que esté poder ok, sino para gestionar.",
-        "Verificar si manifestaron algo del pedido de vista de solicitud clausura sino solicitar pase a fallo.",
-        "Verificar si volvió con dictamen fiscal y pasaron autos a despacho sino reclamar.",
-        "Verificar si perito presentó planilla (lo emplazaron a hacerlo dentro de los 10 días) sino ver si contactamos o agendar para pedir emplazamiento.",
-        "Verificar si perito Villarragut compareció (lo emplazaron a hacerlo dentro de los días) sino ver si contactamos o agendar para pedir emplazamiento.",
-        "Anotar que tuvieron por decaido el derecho de anses y que esta ratificado poder y cargar en el sistema si no llega a estar",
-        "Verificar si tuvimos novedades de sentencia de primera instancia sino para empezar a reclamar. Autos",
-        "Cargar fecha judicial",
-        "Anotar a listado de cúmplase.",
-        "Avisar a Sr. que ordenaron cumplimiento y pasos a seguir.",
-        "Revisar liquidación del Sr. para verificar si procedió reajuste automático. Cúmplase",
-        "Hacer escrito solicitando oficio AFIP para que habilite liquidación mediante ley 26970 acompañar captura de pantalla para demostrar que no está la opción.",
-        "Verificar si otorgaron turno sino solicitar emplazamiento.",
-        "Ordenaron cúmplase. Hacer escrito solicita apertura cuenta y certificación honorarios.",
-        "Verificar si otorgaron turno sino para reclamar en ANSES.",
-        "Hacer bluecorp para ejecución + agendar para hacer + a Pao para verificar",
-        "Empezar con medidas preparatorias de ejecución. Descargar liquidaciones, localizar administrativo+ agendar a Pao para hacer formulario cerca de la fecha en que se vence plazo",
-        "Verificar si otorgaron turno sino cuantificar las astreintes ya ordenadas pedir el aumento y nuevo emplazamiento",
-        "Verificar si otorgaron turno sino solicitar nuevo emplazamiento y astreintes.",
-        "Hoy se vence plazo cumplimiento ver si esta encaminado todo para presentar ejecución",
-        "Avisar al Sr. que presentamos ejecución, pasos a seguir y anotar en comunicaciones",
-        "Verificar si salió auto de aprobación de planilla sino ver si empezamos a reclamar.",
-        "Verificar si salió auto de ejecución sino ver si empezamos a reclamar.",
-        "Verificar si ANSES impugnó planilla sino solicitar aprueben y pase a resolver.",
-        "Contestar impugnación",
-        "Verificar si ANSES apeló sentencia de ejecución sino agendar a los 30 días para solicitar embargo",
-        "Avisar que salió sentencia de ejecución, explicar pasos a seguir, pedir CBU y anotar en comunicaciones.",
-        "Anotar que salió sentencia ejecución y regularon honorarios en UMAS",
-        "Verificar si ANSES cumplió sino solicitar embargo.",
-        "Verificar si se hizo efectiva transferencia, denunciar cobro y actualizar deuda.",
-        "Avisar a Sr. que ordenaron transferencia, coordinar por honorarios + agendar",
-        "Verificar si se hizo efectivo embargo sino para reclamar.",
-        "Verificar si AFIP presentó planilla rectificada sino solicitar astreintes.",
-        "Hacer apelación.",
-        "Avisar a cliente que salió sentencia de primera instancia favorable pero debemos esperar si ANSES apela + explicar pasos a seguir + anotar en comunicaciones.",
-        "Avisar a cliente que salió sentencia de primera instancia, pero debemos apelar por algunos complementos que no hicieron lugar + explicar pasos a seguir + anotar en comunicaciones.",
-        "Anotar que salió sentencia de primera instancia, impusieron costas a ANSES y difirieron regulación",
-        "Hacer cálculo de días corridos desde presentación de dda a sentencia.",
-        "Anotar que ya tenemos CBU cuenta.",
-        "Verificar si ANSES apeló sino solicitar certifiquen sentencia firme y ordenen cumplimiento.",
-        "Verificar si ya recibieron Expdte. en JF y dictaron cumplimiento sino para reclamar"
-        );
-        
         String normalizedQuery = query == null ? "" : query.trim().toLowerCase();
 
         if (normalizedQuery.isEmpty()) {
-            return new ArrayList<>(sugerenciasManuales);
+            return new ArrayList<>(SUGERENCIAS_DESCRIPCION_AGENDA);
         }
 
         List<String> resultado = new ArrayList<>();
-        for (String sugerencia : sugerenciasManuales) {
+        for (String sugerencia : SUGERENCIAS_DESCRIPCION_AGENDA) {
             if (sugerencia.toLowerCase().startsWith(normalizedQuery)) {
                 resultado.add(sugerencia);
             }
@@ -1673,5 +1708,4 @@ public void seleccionarVista(String tipo) {
     }}}
 
     
-
 

--- a/web/agenda/Create.xhtml
+++ b/web/agenda/Create.xhtml
@@ -33,6 +33,19 @@
                                 <div class="agenda-section-title">Detalles</div>
 
                                 <div class="agenda-field-group agenda-field-group-full">
+                                    <p:outputLabel value="Descripción sugerida" for="descripcionSugerida" styleClass="agenda-field-label"/>
+                                    <p:selectOneMenu id="descripcionSugerida"
+                                                     value="#{agendaController.descripcionPredeterminada}"
+                                                     filter="true"
+                                                     filterMatchMode="contains"
+                                                     styleClass="agenda-field-control">
+                                        <f:selectItem itemLabel="--Seleccione una opción--" itemValue="#{null}" noSelectionOption="true"/>
+                                        <f:selectItems value="#{agendaController.sugerenciasDescripcionAgenda}"/>
+                                        <p:ajax listener="#{agendaController.aplicarDescripcionPredeterminada}" update="descripcion"/>
+                                    </p:selectOneMenu>
+                                </div>
+
+                                <div class="agenda-field-group agenda-field-group-full">
                                     <p:outputLabel value="Descripción" for="descripcion" styleClass="agenda-field-label"/>
                                     <p:inputTextarea id="descripcion"
                                                      value="#{agendaController.selected.descripcion}"
@@ -92,7 +105,8 @@
                                              value="Guardar"
                                              icon="ui-icon-check"
                                              styleClass="agenda-btn agenda-btn-primary"
-                                             update="display,:AgendaListForm:datalist,:growl"
+                                             resetValues="true"
+                                             update=":AgendaCreateForm,:AgendaListForm:datalist,:growl"
                                              oncomplete="handleSubmit(args,'AgendaCreateDialog');PF('agendasTable').clearFilters()"/>
                         </div>
                     </div>

--- a/web/agenda/CreateAgendaParaActividad.xhtml
+++ b/web/agenda/CreateAgendaParaActividad.xhtml
@@ -20,6 +20,17 @@
                     </div>
                     
                     <div class="hijo">
+                        <p:outputLabel value="Descripción sugerida:" for="descripcionSugeridaActividad" style="font-weight: bold"/><br></br>
+                        <p:selectOneMenu id="descripcionSugeridaActividad"
+                                         value="#{agendaController.descripcionPredeterminada}"
+                                         filter="true"
+                                         filterMatchMode="contains"
+                                         style="width: 100%; margin-bottom: 10px;">
+                            <f:selectItem itemLabel="--Seleccione una opción--" itemValue="#{null}" noSelectionOption="true"/>
+                            <f:selectItems value="#{agendaController.sugerenciasDescripcionAgenda}"/>
+                            <p:ajax listener="#{agendaController.aplicarDescripcionPredeterminadaActividad}" update="descripcion"/>
+                        </p:selectOneMenu>
+
                         <p:outputLabel value="Descripción:" for="descripcion" style="font-weight: bold"/><br></br>
                         <p:inputTextarea id="descripcion"
                                         value="#{agendaController.selectedActividad.descripcion}"

--- a/web/agenda/Create_1.xhtml
+++ b/web/agenda/Create_1.xhtml
@@ -20,6 +20,17 @@
                     </div>
                     
                     <div class="hijo">
+                        <p:outputLabel value="Descripción sugerida" for="descripcionSugeridaReagendar" /><br></br>
+                        <p:selectOneMenu id="descripcionSugeridaReagendar"
+                                         value="#{agendaController.descripcionPredeterminada}"
+                                         filter="true"
+                                         filterMatchMode="contains"
+                                         style="width: 100%; margin-bottom: 10px;">
+                            <f:selectItem itemLabel="--Seleccione una opción--" itemValue="#{null}" noSelectionOption="true"/>
+                            <f:selectItems value="#{agendaController.sugerenciasDescripcionAgenda}"/>
+                            <p:ajax listener="#{agendaController.aplicarDescripcionPredeterminadaReagendar}" update="descripcion"/>
+                        </p:selectOneMenu>
+
                         <p:outputLabel value="Descripción" for="descripcion" /><br></br>
                         <p:inputTextarea id="descripcion"
                                         value="#{agendaController.selectedParaCrearUnaNueva.descripcion}"

--- a/web/expediente/viewEnAgenda/ViewParaAgenda.xhtml
+++ b/web/expediente/viewEnAgenda/ViewParaAgenda.xhtml
@@ -21,6 +21,17 @@
                         </div>
                         <div class="botonesapilados">
 
+                            <p:outputLabel value="Descripción sugerida:" for="descripcionSugerida" style="font-weight: bold" />
+                            <p:selectOneMenu id="descripcionSugerida"
+                                             value="#{agendaController.descripcionPredeterminada}"
+                                             filter="true"
+                                             filterMatchMode="contains"
+                                             style="width: 100%; margin-bottom: 10px;">
+                                <f:selectItem itemLabel="--Seleccione una opción--" itemValue="#{null}" noSelectionOption="true"/>
+                                <f:selectItems value="#{agendaController.sugerenciasDescripcionAgenda}"/>
+                                <p:ajax listener="#{agendaController.aplicarDescripcionPredeterminada}" update="descripcion"/>
+                            </p:selectOneMenu>
+
                             <p:outputLabel value="Actividad:" for="descripcion" style="font-weight: bold" />
                             <p:inputTextarea id="descripcion"
                                             value="#{agendaController.selected.descripcion}"


### PR DESCRIPTION
### Motivation
- Provide a curated set of common agenda descriptions so users can quickly pick and apply a standardized description when creating, rescheduling or creating activity agendas.
- Reduce typing and improve consistency of agenda descriptions across multiple dialog flows.

### Description
- Introduced a new constant `SUGERENCIAS_DESCRIPCION_AGENDA` (a `List<String>`) in `AgendaController` and replaced the previous inline suggestion list in `completeDescripcionAgenda` to centralize suggestions.
- Added a new bean property `descripcionPredeterminada` with getters/setters and three helper methods `aplicarDescripcionPredeterminada`, `aplicarDescripcionPredeterminadaActividad`, and `aplicarDescripcionPredeterminadaReagendar` to apply the selected suggestion to `selected`, `selectedActividad` and `selectedParaCrearUnaNueva` respectively.
- Reset `descripcionPredeterminada` to `null` in relevant `prepare*` methods so dialogs start without a preselected suggestion.
- Wired a new `p:selectOneMenu` suggestion picker into the create/reschedule/activity UI dialogs (`Create.xhtml`, `CreateAgendaParaActividad.xhtml`, `Create_1.xhtml`, and `ViewParaAgenda.xhtml`) and hooked the pickers to the apply methods via `p:ajax` updates; also updated the create dialog save button to `resetValues="true"` and adjusted the update target to refresh the create form.

### Testing
- Ran the project's automated test suite with `mvn test` and the existing tests completed successfully.
- Verified that the new `completeDescripcionAgenda` returns suggestions from the centralized list and that selecting a suggestion applies it to the corresponding agenda form during dialog interactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af441bbac48327b029ee9b68c4a891)