### PR TITLE
Agregar flujo CREAR REUNIÓN para agendar múltiples asistentes

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
@@ -81,6 +81,15 @@ public class TurnoController implements Serializable {
     
     private String expSeleccionado;
     private String asignarExpediente;
+    private List<String> responsablesSeleccionadosReunion;
+
+    public List<String> getResponsablesSeleccionadosReunion() {
+        return responsablesSeleccionadosReunion;
+    }
+
+    public void setResponsablesSeleccionadosReunion(List<String> responsablesSeleccionadosReunion) {
+        this.responsablesSeleccionadosReunion = responsablesSeleccionadosReunion;
+    }
 
     public Turno getSelectedTurnoPasado() {
         return selectedTurnoPasado;
@@ -362,8 +371,13 @@ public class TurnoController implements Serializable {
     public Turno prepareCreate() {
         selected = new Turno();
         selected.setRealizado("No");
+        responsablesSeleccionadosReunion = new ArrayList<>();
         initializeEmbeddableKey();
         return selected;
+    }
+
+    public Turno prepareCreateReunion() {
+        return prepareCreate();
     }
 
     public void create() {
@@ -383,6 +397,62 @@ public class TurnoController implements Serializable {
                 filteredTurnosConSesion = null;
                 filteredturnos = null;
             }
+        }
+    }
+
+    public void createReunion() {
+        if (selected == null || selected.getHoraYDia() == null) {
+            JsfUtil.addErrorMessage("Debe ingresar día y hora para la reunión.");
+            return;
+        }
+
+        if (responsablesSeleccionadosReunion == null || responsablesSeleccionadosReunion.isEmpty()) {
+            JsfUtil.addErrorMessage("Debe seleccionar al menos un asistente.");
+            return;
+        }
+
+        SimpleDateFormat sdf = new SimpleDateFormat(DD_MM_YYYY);
+        String date = sdf.format(selected.getHoraYDia());
+
+        if (validateHolidays(date)) {
+            FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_ERROR, LA_FECHA_SELECCIONADA_NO_ES_VALIDA + POR_SER_FERIADO, POR_SER_FERIADO);
+            FacesContext.getCurrentInstance().addMessage("successInfo", facesMsg);
+            items = null;
+            return;
+        }
+
+        int reunionesCreadas = 0;
+
+        for (String responsable : responsablesSeleccionadosReunion) {
+            if (!isNotBlank(responsable)) {
+                continue;
+            }
+
+            Turno reunion = new Turno();
+            reunion.setHoraYDia(selected.getHoraYDia());
+            reunion.setNombre(selected.getNombre());
+            reunion.setApellido(selected.getApellido());
+            reunion.setNroDeTelefono(selected.getNroDeTelefono());
+            reunion.setProcedencia(selected.getProcedencia());
+            reunion.setObservacion(selected.getObservacion());
+            reunion.setResponsable(responsable);
+            reunion.setTipoDeTurno(selected.getTipoDeTurno());
+            reunion.setOficina(selected.getOficina());
+            reunion.setAsignarExpediente("no");
+            reunion.setOrden(selected.getOrden());
+            reunion.setRealizado("No");
+
+            addConflictWarningsOnCreate(reunion);
+            getFacade().create(reunion);
+            reunionesCreadas++;
+        }
+
+        if (reunionesCreadas > 0) {
+            JsfUtil.addSuccessMessage("Reunión creada para " + reunionesCreadas + " asistentes.");
+            items = null;
+            filteredTurnosConSesion = null;
+            filteredturnos = null;
+            prepareCreate();
         }
     }
 

--- a/web/agenda/List_AgendasTurnos.xhtml
+++ b/web/agenda/List_AgendasTurnos.xhtml
@@ -20,6 +20,7 @@
                 <div style="float: left;width: 100%;">
                     <p:commandButton id="createButton" icon="ui-icon-plus" value="NUEVA AGENDA" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{agendaController.prepareCreate}" update=":AgendaCreateForm" oncomplete="PF('AgendaCreateDialog').show()"/>
                    <p:commandButton id="createButtonTurno"  icon="ui-icon-plus" value="NUEVO TURNO" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{turnoController.prepareCreate}" update=":TurnoCreateForm" oncomplete="PF('TurnoCreateDialog').show()"/>
+                    <p:commandButton id="createButtonReunion" icon="ui-icon-plus" value="CREAR REUNIÓN" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{turnoController.prepareCreateReunion}" update=":ReunionCreateForm" oncomplete="PF('ReunionCreateDialog').show()"/>
                     <p:commandButton id="createAgendaParaActividadButton" icon="ui-icon-plus" value="NUEVA ACTIVIDAD" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{agendaController.prepareCreateActividad()}" update=":AgendaParaActividadCreateForm" oncomplete="PF('AgendaParaActividadCreateDialog').show()"/>
                 </div>
                 <br></br>
@@ -271,6 +272,7 @@
             <ui:include src="CreateAgendaParaActividad.xhtml"/>
             <ui:include src="Create_1.xhtml"/>
             <ui:include src="../turno/Create.xhtml"/>
+            <ui:include src="../turno/CreateReunion.xhtml"/>
             <ui:include src="../turno/Edit.xhtml"/>
             <ui:include src="Edit.xhtml"/>
             <ui:include src="View.xhtml"/>

--- a/web/agenda/List_AgendasTurnosWithSession.xhtml
+++ b/web/agenda/List_AgendasTurnosWithSession.xhtml
@@ -24,6 +24,7 @@
                 <div style="float: right;width: 50%; ">
                     <p:commandButton id="createButton" icon="ui-icon-plus" value="NUEVA AGENDA" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{agendaController.prepareCreate}" update=":AgendaCreateForm" oncomplete="PF('AgendaCreateDialog').show()"/>
                     <p:commandButton id="createButtonTurno"  icon="ui-icon-plus" value="NUEVO TURNO" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{turnoController.prepareCreate}" update=":TurnoCreateForm" oncomplete="PF('TurnoCreateDialog').show()"/>
+                    <p:commandButton id="createButtonReunion" icon="ui-icon-plus" value="CREAR REUNIÓN" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{turnoController.prepareCreateReunion}" update=":ReunionCreateForm" oncomplete="PF('ReunionCreateDialog').show()"/>
                     <p:commandButton id="createAgendaParaActividadButton" icon="ui-icon-plus" value="NUEVA ACTIVIDAD" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{agendaController.prepareCreateActividad()}" update=":AgendaParaActividadCreateForm" oncomplete="PF('AgendaParaActividadCreateDialog').show()"/>
                 </div>
                 <br></br>
@@ -331,6 +332,7 @@
             <ui:include src="CreateAgendaParaActividad.xhtml"/>
             <ui:include src="Create_1.xhtml"/>
             <ui:include src="../turno/Create.xhtml"/>
+            <ui:include src="../turno/CreateReunion.xhtml"/>
             <ui:include src="../turno/Edit.xhtml"/>
             <ui:include src="Edit.xhtml"/>
             <ui:include src="View.xhtml"/>

--- a/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
+++ b/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
@@ -86,6 +86,7 @@
                 <div style="float: right;width: 30%;">
                     <p:commandButton id="createButton" icon="ui-icon-plus" value="NUEVA AGENDA" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{agendaController.prepareCreate}" update=":AgendaCreateForm" oncomplete="PF('AgendaCreateDialog').show()"/>
                     <p:commandButton id="createButtonTurno"  icon="ui-icon-plus" value="NUEVO TURNO" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{turnoController.prepareCreate}" update=":TurnoCreateForm" oncomplete="PF('TurnoCreateDialog').show()"/>
+                    <p:commandButton id="createButtonReunion" icon="ui-icon-plus" value="CREAR REUNIÓN" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{turnoController.prepareCreateReunion}" update=":ReunionCreateForm" oncomplete="PF('ReunionCreateDialog').show()"/>
                     <p:commandButton id="createAgendaParaActividadButton" icon="ui-icon-plus" value="NUEVA ACTIVIDAD" class="botonCrearAgenda borderRd mrgLR2 hoverGreen" actionListener="#{agendaController.prepareCreateActividad()}" update=":AgendaParaActividadCreateForm" oncomplete="PF('AgendaParaActividadCreateDialog').show()"/>
                 </div>
                 <br></br>
@@ -379,6 +380,7 @@
             <ui:include src="CreateAgendaParaActividad.xhtml"/>
             <ui:include src="Create_1.xhtml"/>
             <ui:include src="../turno/Create.xhtml"/>
+            <ui:include src="../turno/CreateReunion.xhtml"/>
             <ui:include src="../turno/Edit.xhtml"/>
             <ui:include src="Edit.xhtml"/>
             <ui:include src="View.xhtml"/>

--- a/web/turno/CreateReunion.xhtml
+++ b/web/turno/CreateReunion.xhtml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+    <ui:composition>
+
+        <p:dialog id="ReunionCreateDlg" widgetVar="ReunionCreateDialog" modal="true" resizable="false" appendTo="@(body)" header="Crear reunión">
+            <h:form id="ReunionCreateForm">
+                <h:panelGroup id="displayReunion">
+                    <h:panelGrid columns="2" cellpadding="5">
+                        <p:outputLabel value="Día y hora:" for="horaYDiaReunion" style="font-weight: bold"/>
+                        <p:calendar id="horaYDiaReunion" pattern="dd/MM/yyyy HH:mm" placeholder="dd/MM/yyyy HH:mm" autocomplete="off"
+                                    value="#{turnoController.selected.horaYDia}" showOn="false"/>
+
+                        <p:outputLabel value="Asunto:" for="apellidoReunion" style="font-weight: bold"/>
+                        <p:inputText id="apellidoReunion" value="#{turnoController.selected.apellido}" />
+
+                        <p:outputLabel value="Detalle:" for="observacionReunion" style="font-weight: bold"/>
+                        <p:inputTextarea id="observacionReunion" cols="33" rows="5" autoResize="false" value="#{turnoController.selected.observacion}"/>
+
+                        <p:outputLabel value="Tipo de Turno:" for="tipoDeTurnoReunion" style="font-weight: bold"/>
+                        <p:selectOneMenu id="tipoDeTurnoReunion" value="#{turnoController.selected.tipoDeTurno}" editable="true" effect="fold">
+                            <f:selectItem itemLabel="TELEFÓNICO" itemValue="TELEFÓNICO" />
+                            <f:selectItem itemLabel="PRESENCIAL" itemValue="PRESENCIAL" />
+                            <p:ajax update="oficinaReunion" />
+                        </p:selectOneMenu>
+
+                        <p:outputLabel value="Oficina:" for="oficinaReunion" style="font-weight: bold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}"/>
+                        <p:selectOneMenu id="oficinaReunion" value="#{turnoController.selected.oficina}" editable="true" effect="fold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}">
+                            <f:selectItem itemLabel="CERRO" itemValue="CERRO" />
+                            <f:selectItem itemLabel="CENTRO" itemValue="CENTRO" />
+                        </p:selectOneMenu>
+                    </h:panelGrid>
+
+                    <p:outputLabel value="Asistentes:" style="font-weight: bold"/>
+                    <p:selectCheckboxMenu id="asistentes" label="Seleccionar asistentes" filter="true" filterMatchMode="contains"
+                                          panelStyle="width: 350px" scrollHeight="220"
+                                          value="#{turnoController.responsablesSeleccionadosReunion}">
+                        <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
+                                       itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"/>
+                    </p:selectCheckboxMenu>
+
+                    <br/><br/>
+
+                    <p:commandButton actionListener="#{turnoController.createReunion}"
+                                     class="botonCrear"
+                                     value="Guardar reunión"
+                                     update="displayReunion,:TurnoListForm:datalist,:growl"
+                                     oncomplete="handleSubmit(args,'ReunionCreateDialog');PF('turnosTable').clearFilters()"/>
+
+                    <p:commandButton value="#{bundle.Cancel}" onclick="ReunionCreateDialog.hide()"/>
+                </h:panelGroup>
+            </h:form>
+        </p:dialog>
+
+    </ui:composition>
+</html>


### PR DESCRIPTION
### Motivation
- Añadir una forma de crear una única "reunión" y que se genere un turno para cada asistente seleccionado para evitar tener que agendar turnos uno por uno.

### Description
- Se agregó soporte en `TurnoController` para seleccionar múltiples responsables (`responsablesSeleccionadosReunion`) con getters/setters y se inicializa en `prepareCreate()`; se añadió `prepareCreateReunion()` como atajo. 
- Se implementó `createReunion()` en `TurnoController` que valida feriados, reutiliza la lógica de advertencias de conflicto y crea un `Turno` por cada responsable seleccionado. 
- Se añadió la vista/dialog `web/turno/CreateReunion.xhtml` con campos de fecha/hora, asunto, detalle, tipo/oficina y un `selectCheckboxMenu` para elegir asistentes. 
- Se insertó el botón `CREAR REUNIÓN` y el `ui:include` del nuevo diálogo en las pantallas de agenda `List_AgendasTurnos.xhtml`, `List_AgendasTurnosWithSession.xhtml` y `List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml` para exponer la funcionalidad. 

### Testing
- Intenté compilar con `ant -q compile`, pero falló por limitación del entorno porque `ant` no está instalado (compilación no ejecutada). 
- Intenté verificar la UI con Playwright apuntando a `http://localhost:8080` para tomar una captura, pero el servidor no respondió (`ERR_EMPTY_RESPONSE`), por lo que no se pudo validar visualmente ni ejecutar pruebas E2E.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22f9577dc8327a4a037e36845b320)