### PR TITLE
Agregar tab 'Sentencias' (5 espacios) con soporte completo de upload/download y tablas DB

### DIFF
--- a/CREATE_TABLE_DOCUMENTOS_SENTENCIAS.sql
+++ b/CREATE_TABLE_DOCUMENTOS_SENTENCIAS.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS documentosSentencias (
+    nroDeOrden INT NOT NULL,
+    documento LONGBLOB,
+    nombreDelDocumento VARCHAR(255),
+    PRIMARY KEY (nroDeOrden)
+);
+
+CREATE TABLE IF NOT EXISTS documentosSentenciasDos (
+    nroDeOrden INT NOT NULL,
+    documento LONGBLOB,
+    nombreDelDocumento VARCHAR(255),
+    PRIMARY KEY (nroDeOrden)
+);
+
+CREATE TABLE IF NOT EXISTS documentosSentenciasTres (
+    nroDeOrden INT NOT NULL,
+    documento LONGBLOB,
+    nombreDelDocumento VARCHAR(255),
+    PRIMARY KEY (nroDeOrden)
+);
+
+CREATE TABLE IF NOT EXISTS documentosSentenciasCuatro (
+    nroDeOrden INT NOT NULL,
+    documento LONGBLOB,
+    nombreDelDocumento VARCHAR(255),
+    PRIMARY KEY (nroDeOrden)
+);
+
+CREATE TABLE IF NOT EXISTS documentosSentenciasCinco (
+    nroDeOrden INT NOT NULL,
+    documento LONGBLOB,
+    nombreDelDocumento VARCHAR(255),
+    PRIMARY KEY (nroDeOrden)
+);

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileDownloadBean.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileDownloadBean.java
@@ -75,6 +75,11 @@ public class FileDownloadBean implements Serializable {
     private StreamedContent fileRecibosDos;
     private StreamedContent fileRecibosTres;
     private StreamedContent fileRecibosCuatro;
+    private StreamedContent fileSentencias;
+    private StreamedContent fileSentenciasDos;
+    private StreamedContent fileSentenciasTres;
+    private StreamedContent fileSentenciasCuatro;
+    private StreamedContent fileSentenciasCinco;
     
     
     private StreamedContent fileLiquidacionBlueCorp;
@@ -317,6 +322,46 @@ public class FileDownloadBean implements Serializable {
 
     public void setFileRecibosCuatro(StreamedContent fileRecibosCuatro) {
         this.fileRecibosCuatro = fileRecibosCuatro;
+    }
+
+    public StreamedContent getFileSentencias() {
+        return fileSentencias;
+    }
+
+    public void setFileSentencias(StreamedContent fileSentencias) {
+        this.fileSentencias = fileSentencias;
+    }
+
+    public StreamedContent getFileSentenciasDos() {
+        return fileSentenciasDos;
+    }
+
+    public void setFileSentenciasDos(StreamedContent fileSentenciasDos) {
+        this.fileSentenciasDos = fileSentenciasDos;
+    }
+
+    public StreamedContent getFileSentenciasTres() {
+        return fileSentenciasTres;
+    }
+
+    public void setFileSentenciasTres(StreamedContent fileSentenciasTres) {
+        this.fileSentenciasTres = fileSentenciasTres;
+    }
+
+    public StreamedContent getFileSentenciasCuatro() {
+        return fileSentenciasCuatro;
+    }
+
+    public void setFileSentenciasCuatro(StreamedContent fileSentenciasCuatro) {
+        this.fileSentenciasCuatro = fileSentenciasCuatro;
+    }
+
+    public StreamedContent getFileSentenciasCinco() {
+        return fileSentenciasCinco;
+    }
+
+    public void setFileSentenciasCinco(StreamedContent fileSentenciasCinco) {
+        this.fileSentenciasCinco = fileSentenciasCinco;
     }
     
     public StreamedContent getFileLiquidacionBlueCorp() {
@@ -1881,6 +1926,26 @@ public class FileDownloadBean implements Serializable {
                                 fileRecibosCuatro = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
                                 fileAlmacenado = fileRecibosCuatro;
                                 break;    
+                            case "Sentencias":
+                                fileSentencias = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentencias;
+                                break;
+                            case "SentenciasDos":
+                                fileSentenciasDos = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasDos;
+                                break;
+                            case "SentenciasTres":
+                                fileSentenciasTres = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasTres;
+                                break;
+                            case "SentenciasCuatro":
+                                fileSentenciasCuatro = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasCuatro;
+                                break;
+                            case "SentenciasCinco":
+                                fileSentenciasCinco = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasCinco;
+                                break;
                                 
                             case "LiquidacionBlueCorp":
                                 fileLiquidacionBlueCorp = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
@@ -1971,6 +2036,26 @@ public class FileDownloadBean implements Serializable {
                             case "RecibosCuatro":
                                 fileRecibosCuatro = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
                                 fileAlmacenado = fileRecibosCuatro;
+                                break;
+                            case "Sentencias":
+                                fileSentencias = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentencias;
+                                break;
+                            case "SentenciasDos":
+                                fileSentenciasDos = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasDos;
+                                break;
+                            case "SentenciasTres":
+                                fileSentenciasTres = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasTres;
+                                break;
+                            case "SentenciasCuatro":
+                                fileSentenciasCuatro = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasCuatro;
+                                break;
+                            case "SentenciasCinco":
+                                fileSentenciasCinco = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileSentenciasCinco;
                                 break;
                             case "LiquidacionBlueCorp":
                                 fileLiquidacionBlueCorp = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
@@ -3099,6 +3184,21 @@ public class FileDownloadBean implements Serializable {
             } else {
 
                 return cantidad;
+            }
+        }
+
+        return cantidad;
+    }
+
+    public int cantidadSentencias(int orden) {
+        int cantidad = 0;
+
+        if (orden != 0) {
+            String[] nombres = {"Sentencias", "SentenciasDos", "SentenciasTres", "SentenciasCuatro", "SentenciasCinco"};
+            for (String nombreArchivo : nombres) {
+                if (!buscarNombreDeArchivo(orden, nombreArchivo).contains("no existe archivo")) {
+                    cantidad += 1;
+                }
             }
         }
 

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileUploadBean.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileUploadBean.java
@@ -66,6 +66,11 @@ public class FileUploadBean implements Serializable{
         private UploadedFile fileRecibosDos;
         private UploadedFile fileRecibosTres;
         private UploadedFile fileRecibosCuatro;
+        private UploadedFile fileSentencias;
+        private UploadedFile fileSentenciasDos;
+        private UploadedFile fileSentenciasTres;
+        private UploadedFile fileSentenciasCuatro;
+        private UploadedFile fileSentenciasCinco;
         
         private UploadedFile fileLiquidacionBlueCorp;
         private UploadedFile fileLiquidacionBlueCorpDos;
@@ -164,6 +169,46 @@ public class FileUploadBean implements Serializable{
 
     public void setFileRecibosCuatro(UploadedFile fileRecibosCuatro) {
         this.fileRecibosCuatro = fileRecibosCuatro;
+    }
+
+    public UploadedFile getFileSentencias() {
+        return fileSentencias;
+    }
+
+    public void setFileSentencias(UploadedFile fileSentencias) {
+        this.fileSentencias = fileSentencias;
+    }
+
+    public UploadedFile getFileSentenciasDos() {
+        return fileSentenciasDos;
+    }
+
+    public void setFileSentenciasDos(UploadedFile fileSentenciasDos) {
+        this.fileSentenciasDos = fileSentenciasDos;
+    }
+
+    public UploadedFile getFileSentenciasTres() {
+        return fileSentenciasTres;
+    }
+
+    public void setFileSentenciasTres(UploadedFile fileSentenciasTres) {
+        this.fileSentenciasTres = fileSentenciasTres;
+    }
+
+    public UploadedFile getFileSentenciasCuatro() {
+        return fileSentenciasCuatro;
+    }
+
+    public void setFileSentenciasCuatro(UploadedFile fileSentenciasCuatro) {
+        this.fileSentenciasCuatro = fileSentenciasCuatro;
+    }
+
+    public UploadedFile getFileSentenciasCinco() {
+        return fileSentenciasCinco;
+    }
+
+    public void setFileSentenciasCinco(UploadedFile fileSentenciasCinco) {
+        this.fileSentenciasCinco = fileSentenciasCinco;
     }
     
     
@@ -2032,9 +2077,24 @@ public class FileUploadBean implements Serializable{
                  fileParaSubir = fileRecibosTres;
                  break;
             
-             case "RecibosCuatro":
+            case "RecibosCuatro":
                  fileParaSubir = fileRecibosCuatro;
                  break;     
+            case "Sentencias":
+                 fileParaSubir = fileSentencias;
+                 break;
+            case "SentenciasDos":
+                 fileParaSubir = fileSentenciasDos;
+                 break;
+            case "SentenciasTres":
+                 fileParaSubir = fileSentenciasTres;
+                 break;
+            case "SentenciasCuatro":
+                 fileParaSubir = fileSentenciasCuatro;
+                 break;
+            case "SentenciasCinco":
+                 fileParaSubir = fileSentenciasCinco;
+                 break;
                  
             case "LiquidacionBlueCorp":
                  fileParaSubir = fileLiquidacionBlueCorp;

--- a/web/expediente/ViewDocumentos.xhtml
+++ b/web/expediente/ViewDocumentos.xhtml
@@ -343,6 +343,108 @@
                                 </div>
                             </p:panel>
                         </p:tab>
+                        <p:tab>
+                            <f:facet name="title">
+                                Sentencias
+                                <span class="circle-badge"  style=" #{fileDownloadBean.cantidadSentencias(expedienteController.selected.orden) == 0 ? 'background: #e87474; ' : 'background: #00c6ae;'}">
+                                    #{fileDownloadBean.cantidadSentencias(expedienteController.selected.orden)}
+                                </span>
+                            </f:facet>
+
+                            <p:panel
+                                rendered="#{expedienteController.selected.tipoDeExpediente eq 'judicial' or expedienteController.selected.tipoDeExpediente eq 'administrativo'}"
+                                id="sentencias"
+                                header="Sentencias"
+                                toggleable="false"
+                                closable="false"
+                                collapsed="false"
+                                toggleSpeed="500"
+                                closeSpeed="500"
+                                >
+                                <div class="contenedorcard">
+                                    <div class="cards1"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'Sentencias').toString().contains('no existe archivo') ? 'border: 3px solid #e87474;background: #ffd5d5; ' : 'border:3px solid #00c6ae;background: #d0fff9;'}">
+                                        <p:outputLabel value="Nombre del archivo Sentencia 1:" styleClass="titulopdfjpg"/>
+                                        <br></br>
+                                        <p:outputLabel value="#{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'Sentencias')}"
+                                                       styleClass="buscararchivo"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'Sentencias').toString().contains('no existe archivo') ? 'background-color: #e87474; color: #780C28 ;' : 'background-color: #80d3bb; color:#11665c ;border-left: 5px solid #11665c;'}"/>
+                                        <br></br>
+                                        <p:growl life="2500" showDetail="true"/>
+                                        <p:fileUpload value="#{fileUploadBean.fileSentencias}" mode="simple"/>
+                                        <div style="display: flex; gap: 10px; margin-top: 10px;">
+                                            <p:commandButton icon="fa-upload" value="Subir archivo" class="botonsubirbajarpdf" action="#{fileUploadBean.uploadDocumentoPorNombre(expedienteController.selected.orden, 'Sentencias')}" ajax="false" />
+                                            <p:commandButton class="botonsubirbajarpdf" value="Descargar archivo" actionListener="#{fileDownloadBean.downloadDocumentoPorNombre(expedienteController.selected.orden, 'Sentencias')}" ajax="false">
+                                                <p:fileDownload value="#{fileDownloadBean.fileSentencias}" />
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+
+                                    <div class="cards1"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasDos').toString().contains('no existe archivo') ? 'border: 3px solid #e87474;background: #ffd5d5; ' : 'border:3px solid #00c6ae;background: #d0fff9;'}">
+                                        <p:outputLabel value="Nombre del archivo Sentencia 2:" styleClass="titulopdfjpg"/>
+                                        <br></br>
+                                        <p:outputLabel value="#{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasDos')}"
+                                                       styleClass="buscararchivo"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasDos').toString().contains('no existe archivo') ? 'background-color: #e87474; color: #780C28 ;' : 'background-color: #80d3bb; color:#11665c ;border-left: 5px solid #11665c;'}"/>
+                                        <br></br>
+                                        <p:growl life="2500" showDetail="true"/>
+                                        <p:fileUpload value="#{fileUploadBean.fileSentenciasDos}" mode="simple"/>
+                                        <div style="display: flex; gap: 10px; margin-top: 10px;">
+                                            <p:commandButton icon="fa-upload" value="Subir archivo" class="botonsubirbajarpdf" action="#{fileUploadBean.uploadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasDos')}" ajax="false" />
+                                            <p:commandButton class="botonsubirbajarpdf" value="Descargar archivo" actionListener="#{fileDownloadBean.downloadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasDos')}" ajax="false">
+                                                <p:fileDownload value="#{fileDownloadBean.fileSentenciasDos}" />
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+
+                                    <div class="cards1"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasTres').toString().contains('no existe archivo') ? 'border: 3px solid #e87474;background: #ffd5d5; ' : 'border:3px solid #00c6ae;background: #d0fff9;'}">
+                                        <p:outputLabel value="Nombre del archivo Sentencia 3:" styleClass="titulopdfjpg"/>
+                                        <br></br>
+                                        <p:outputLabel value="#{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasTres')}"
+                                                       styleClass="buscararchivo"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasTres').toString().contains('no existe archivo') ? 'background-color: #e87474; color: #780C28 ;' : 'background-color: #80d3bb; color:#11665c ;border-left: 5px solid #11665c;'}"/>
+                                        <br></br>
+                                        <p:growl life="2500" showDetail="true"/>
+                                        <p:fileUpload value="#{fileUploadBean.fileSentenciasTres}" mode="simple"/>
+                                        <div style="display: flex; gap: 10px; margin-top: 10px;">
+                                            <p:commandButton icon="fa-upload" value="Subir archivo" class="botonsubirbajarpdf" action="#{fileUploadBean.uploadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasTres')}" ajax="false" />
+                                            <p:commandButton class="botonsubirbajarpdf" value="Descargar archivo" actionListener="#{fileDownloadBean.downloadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasTres')}" ajax="false">
+                                                <p:fileDownload value="#{fileDownloadBean.fileSentenciasTres}" />
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+
+                                    <div class="cards1"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasCuatro').toString().contains('no existe archivo') ? 'border: 3px solid #e87474;background: #ffd5d5; ' : 'border:3px solid #00c6ae;background: #d0fff9;'}">
+                                        <p:outputLabel value="Nombre del archivo Sentencia 4:" styleClass="titulopdfjpg"/>
+                                        <br></br>
+                                        <p:outputLabel value="#{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasCuatro')}"
+                                                       styleClass="buscararchivo"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasCuatro').toString().contains('no existe archivo') ? 'background-color: #e87474; color: #780C28 ;' : 'background-color: #80d3bb; color:#11665c ;border-left: 5px solid #11665c;'}"/>
+                                        <br></br>
+                                        <p:growl life="2500" showDetail="true"/>
+                                        <p:fileUpload value="#{fileUploadBean.fileSentenciasCuatro}" mode="simple"/>
+                                        <div style="display: flex; gap: 10px; margin-top: 10px;">
+                                            <p:commandButton icon="fa-upload" value="Subir archivo" class="botonsubirbajarpdf" action="#{fileUploadBean.uploadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasCuatro')}" ajax="false" />
+                                            <p:commandButton class="botonsubirbajarpdf" value="Descargar archivo" actionListener="#{fileDownloadBean.downloadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasCuatro')}" ajax="false">
+                                                <p:fileDownload value="#{fileDownloadBean.fileSentenciasCuatro}" />
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+
+                                    <div class="cards1"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasCinco').toString().contains('no existe archivo') ? 'border: 3px solid #e87474;background: #ffd5d5; ' : 'border:3px solid #00c6ae;background: #d0fff9;'}">
+                                        <p:outputLabel value="Nombre del archivo Sentencia 5:" styleClass="titulopdfjpg"/>
+                                        <br></br>
+                                        <p:outputLabel value="#{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasCinco')}"
+                                                       styleClass="buscararchivo"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'SentenciasCinco').toString().contains('no existe archivo') ? 'background-color: #e87474; color: #780C28 ;' : 'background-color: #80d3bb; color:#11665c ;border-left: 5px solid #11665c;'}"/>
+                                        <br></br>
+                                        <p:growl life="2500" showDetail="true"/>
+                                        <p:fileUpload value="#{fileUploadBean.fileSentenciasCinco}" mode="simple"/>
+                                        <div style="display: flex; gap: 10px; margin-top: 10px;">
+                                            <p:commandButton icon="fa-upload" value="Subir archivo" class="botonsubirbajarpdf" action="#{fileUploadBean.uploadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasCinco')}" ajax="false" />
+                                            <p:commandButton class="botonsubirbajarpdf" value="Descargar archivo" actionListener="#{fileDownloadBean.downloadDocumentoPorNombre(expedienteController.selected.orden, 'SentenciasCinco')}" ajax="false">
+                                                <p:fileDownload value="#{fileDownloadBean.fileSentenciasCinco}" />
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+                                </div>
+                            </p:panel>
+                        </p:tab>
+
                         <p:tab >
                             <f:facet name="title">
                                 Historial laboral otras cajas


### PR DESCRIPTION
### Motivation
- Añadir una sección "Sentencias" en `ViewDocumentos` con 5 espacios independientes para guardar hasta 5 sentencias por expediente. 
- Proveer soporte completo de subida/descarga y contador visual (badge) para esos 5 espacios, manteniendo el flujo existente de `uploadDocumentoPorNombre` / `downloadDocumentoPorNombre`.

### Description
- Se agregó el tab "Sentencias" en `web/expediente/ViewDocumentos.xhtml` con 5 cards (Sentencia 1..5), cada una con visualización de nombre, `p:fileUpload` y botones para subir/descargar usando `uploadDocumentoPorNombre`/`downloadDocumentoPorNombre`.
- En `src/java/.../FileUploadBean.java` se añadieron 5 propiedades `UploadedFile` (`fileSentencias*`) con sus getters/setters y se amplió el `switch` en `uploadDocumentoPorNombre(...)` para manejar los 5 nombres (`Sentencias`, `SentenciasDos`... `SentenciasCinco`).
- En `src/java/.../FileDownloadBean.java` se añadieron 5 propiedades `StreamedContent` (`fileSentencias*`) con getters/setters, se extendió `downloadDocumentoPorNombre(...)` para mapear JPG/PDF a estas propiedades y se implementó `cantidadSentencias(int orden)` para calcular el badge.
- Se añadió el script `CREATE_TABLE_DOCUMENTOS_SENTENCIAS.sql` que crea las 5 tablas nuevas (`documentosSentencias`, `documentosSentenciasDos`, `documentosSentenciasTres`, `documentosSentenciasCuatro`, `documentosSentenciasCinco`) para el almacenamiento binario de los documentos.

### Testing
- Se ejecutó la verificación de diferencias/estilo con `git diff --check` y no arrojó problemas.
- Se intentó compilar con `ant -q compile` pero no se pudo ejecutar en este entorno porque `ant` no está instalado, por lo que la compilación automatizada no se pudo validar aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03c07c6a88327acd45112d7d75db4)