### PR TITLE
Set default equipo for new consultas to PREVISIONAL ADMINISTRATIVO

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/ConsultaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ConsultaController.java
@@ -206,6 +206,7 @@ public class ConsultaController implements Serializable {
         
         initializeEmbeddableKey();
         selected.setFechaDeAtencion(new Date());
+        selected.setEquipo("PREVISIONAL ADMINISTRATIVO");
         return selected;
     }
 


### PR DESCRIPTION
### Motivation
- Al crear una nueva `Consulta` se debe preseleccionar el equipo por defecto como `PREVISIONAL ADMINISTRATIVO` para agilizar la carga y evitar elegir manualmente el equipo cada vez.

### Description
- Se actualizó `ConsultaController.prepareCreate()` en `src/java/com/estudioAlvarezVersion2/jsf/ConsultaController.java` para inicializar `selected.setEquipo("PREVISIONAL ADMINISTRATIVO")` al crear una nueva consulta.

### Testing
- Se ejecutó `ant -q compile` en este entorno y falló porque `ant` no está disponible, por lo que no se pudo validar la compilación automáticamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e454a71b008327965219671f53a5da)