### PR TITLE
Agregar semáforo de reagendado en vista onlyAdminUsers

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
@@ -1296,6 +1296,33 @@ public class AgendaController implements Serializable {
     public List<Agenda> getItemsByOrder(Integer orden) {
         return getFacade().getItemsByOrder(orden);
     }
+
+    public int contarReagendadasPorOrden(Agenda agenda) {
+        if (agenda == null || agenda.getOrden() == null || agenda.getOrden() <= 0) {
+            return 0;
+        }
+
+        int cantidadReagendadas = 0;
+        List<Agenda> agendasMismoOrden = getItemsByOrder(agenda.getOrden());
+
+        for (Agenda agendaPorOrden : agendasMismoOrden) {
+            if (agendaPorOrden != null && "Reagendada".equalsIgnoreCase(agendaPorOrden.getRealizado())) {
+                cantidadReagendadas++;
+            }
+        }
+
+        return cantidadReagendadas;
+    }
+
+    public boolean mostrarSemaforoAmarillo(Agenda agenda) {
+        int cantidadReagendadas = contarReagendadasPorOrden(agenda);
+        return cantidadReagendadas > 3 && cantidadReagendadas <= 6;
+    }
+
+    public boolean mostrarSemaforoRojo(Agenda agenda) {
+        return contarReagendadasPorOrden(agenda) > 6;
+    }
+
     
     public List<Agenda> getItemsBySessionUser(String userNombreCompleto, String dateStr) {
         Date date = null;

--- a/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
+++ b/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
@@ -299,6 +299,14 @@
                         <p:commandButton class="linea btnSearch"  update=":AgendaEditForm" oncomplete="PF('AgendaEditDialog').show()" icon="ui-icon-search" title="Ver Agenda">
                             <f:setPropertyActionListener value="#{item}" target="#{agendaController.selected}" />
                         </p:commandButton>
+
+                        <h:panelGroup rendered="#{agendaController.mostrarSemaforoAmarillo(item)}"
+                                      title="Atención: esta agenda ya fue reagendada #{agendaController.contarReagendadasPorOrden(item)} veces"
+                                      style="display: inline-block; margin-left: 4px; width: 10px; height: 10px; border-radius: 50%; background-color: #f1c40f; border: 1px solid #b7950b; vertical-align: middle;" />
+
+                        <h:panelGroup rendered="#{agendaController.mostrarSemaforoRojo(item)}"
+                                      title="Alerta: esta agenda ya fue reagendada #{agendaController.contarReagendadasPorOrden(item)} veces"
+                                      style="display: inline-block; margin-left: 4px; width: 10px; height: 10px; border-radius: 50%; background-color: #e74c3c; border: 1px solid #922b21; vertical-align: middle;" />
                         
                         <p:commandButton rendered="#{item.orden > 0 }" class="linea btnKey"  update=":AgendaViewClavesForm" oncomplete="PF('AgendaViewClavesDialog').show()" icon="ui-icon-locked" title="Claves">
                             <f:setPropertyActionListener value="#{item}" target="#{agendaController.selected}" />


### PR DESCRIPTION
### Motivation

- Mostrar una alerta visual en la vista `onlyAdminUsers` (el "ojito") cuando una misma agenda (mismo `orden`) fue reagendada repetidas veces para facilitar la detección por parte de líderes. 
- Definir umbrales claros: amarillo cuando hay más de 3 reagendadas y hasta 6, y rojo cuando supera 6.
- Mantener la lógica central en el `AgendaController` reutilizando campos ya existentes (`orden` y `realizado`) para no alterar el modelo de datos.

### Description

- Se añadió en `AgendaController` los métodos `contarReagendadasPorOrden(Agenda)`, `mostrarSemaforoAmarillo(Agenda)` y `mostrarSemaforoRojo(Agenda)` que cuentan agendas con `realizado = 'Reagendada'` para el mismo `orden` y calculan el estado del semáforo. 
- Se agregó en la vista `web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml` dos indicadores (`h:panelGroup`) junto al botón `Ver Agenda` para mostrar un punto amarillo o rojo según corresponda, incluyendo un `title` con la cantidad detectada. 
- Los cambios están comiteados y listos: archivos modificados `src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java` y `web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml`.

### Testing

- Se intentó compilar con `ant -q compile` pero falló porque `ant` no está disponible en este entorno, por lo que no se pudo ejecutar la verificación de compilación automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e45723bf808327a0161ecf3cd2669c)