### PR TITLE
Reubicar semáforo de reagendadas en acciones de onlyAdminUsers

### DIFF
--- a/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
+++ b/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
@@ -300,17 +300,17 @@
                             <f:setPropertyActionListener value="#{item}" target="#{agendaController.selected}" />
                         </p:commandButton>
 
-                        <h:panelGroup rendered="#{agendaController.mostrarSemaforoAmarillo(item)}"
-                                      title="Atención: esta agenda ya fue reagendada #{agendaController.contarReagendadasPorOrden(item)} veces"
-                                      style="display: inline-block; margin-left: 4px; width: 10px; height: 10px; border-radius: 50%; background-color: #f1c40f; border: 1px solid #b7950b; vertical-align: middle;" />
-
-                        <h:panelGroup rendered="#{agendaController.mostrarSemaforoRojo(item)}"
-                                      title="Alerta: esta agenda ya fue reagendada #{agendaController.contarReagendadasPorOrden(item)} veces"
-                                      style="display: inline-block; margin-left: 4px; width: 10px; height: 10px; border-radius: 50%; background-color: #e74c3c; border: 1px solid #922b21; vertical-align: middle;" />
-                        
                         <p:commandButton rendered="#{item.orden > 0 }" class="linea btnKey"  update=":AgendaViewClavesForm" oncomplete="PF('AgendaViewClavesDialog').show()" icon="ui-icon-locked" title="Claves">
                             <f:setPropertyActionListener value="#{item}" target="#{agendaController.selected}" />
                         </p:commandButton>
+
+                        <h:panelGroup rendered="#{agendaController.mostrarSemaforoAmarillo(item)}"
+                                      title="Atención: esta agenda ya fue reagendada #{agendaController.contarReagendadasPorOrden(item)} veces"
+                                      style="display: inline-block; margin: 0 4px 0 0; width: 10px; height: 10px; border-radius: 50%; background-color: #f1c40f; border: 1px solid #b7950b; vertical-align: middle;" />
+
+                        <h:panelGroup rendered="#{agendaController.mostrarSemaforoRojo(item)}"
+                                      title="Alerta: esta agenda ya fue reagendada #{agendaController.contarReagendadasPorOrden(item)} veces"
+                                      style="display: inline-block; margin: 0 4px 0 0; width: 10px; height: 10px; border-radius: 50%; background-color: #e74c3c; border: 1px solid #922b21; vertical-align: middle;" />
 
                         <p:commandButton class="linea btnSearchDarkBlue"
                                          actionListener="#{expedienteController.prepareViewParaExpediente(item)}" 


### PR DESCRIPTION
### Motivation
- Mover el indicador visual de reagendadas (semáforo amarillo/rojo) a la posición solicitada dentro de la columna de `ACCIONES` para mejorar la detección por parte de líderes. 
- Mantener la lógica existente del `AgendaController` (conteo y umbrales) sin cambios en el backend.

### Description
- Reubicado el `h:panelGroup` del semáforo (amarillo/rojo) dentro de `web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml` colocándolo inmediatamente después del botón `Claves` en la columna de acciones. 
- Ajustado el estilo de separación (`margin: 0 4px 0 0`) para que el punto quede correctamente espaciado en su nueva ubicación. 
- No se tocaron métodos ni lógica en `AgendaController`; el cambio es puramente de presentación en la vista JSF.

### Testing
- Ejecutado `git status --short` para verificar cambios y `git show --stat --oneline HEAD` para revisar el commit, ambos comandos completaron correctamente. 
- Commit aplicado con éxito (`Reubicar semáforo de reagendadas en acciones de onlyAdminUsers`).
- No se ejecutaron tests automáticos de UI en este cambio (solo verificación de control de versiones y diff).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8112db58c83279bcad2e9be9c9605)