### PR TITLE
Mejorar semáforo: rachas consecutivas por descripción y orden

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
@@ -71,6 +72,7 @@ public class AgendaController implements Serializable {
 
     private List<Agenda> items = null;
     private List<Agenda> itemsitemsWithSession = null;
+    private transient Map<String, Integer> rachaConsecutivaPorClaveSemaforo = null;
     
     private static final String DD_MM_YYYY = "dd/MM/yyyy";
     private static final String LA_FECHA_SELECCIONADA_NO_ES_VALIDA = "la fecha selecionada no es válida";
@@ -1268,6 +1270,7 @@ public class AgendaController implements Serializable {
     public List<Agenda> getItems() {
         if (items == null) {
             items = getFacade().findAllSortedByDate();
+            rachaConsecutivaPorClaveSemaforo = null;
         }
         //List<Agenda> cloned_list;
 
@@ -1297,30 +1300,84 @@ public class AgendaController implements Serializable {
         return getFacade().getItemsByOrder(orden);
     }
 
-    public int contarReagendadasPorOrden(Agenda agenda) {
+    private String construirClaveSemaforo(Agenda agenda) {
         if (agenda == null || agenda.getOrden() == null || agenda.getOrden() <= 0) {
+            return null;
+        }
+
+        String descripcion = agenda.getDescripcion();
+        if (descripcion == null) {
+            return null;
+        }
+
+        String descripcionNormalizada = descripcion.trim();
+        if (descripcionNormalizada.isEmpty()) {
+            return null;
+        }
+
+        return agenda.getOrden() + "|" + descripcionNormalizada;
+    }
+
+    private void construirCacheSemaforoPorRachasConsecutivas() {
+        if (rachaConsecutivaPorClaveSemaforo != null) {
+            return;
+        }
+
+        rachaConsecutivaPorClaveSemaforo = new HashMap<>();
+        Map<String, Set<LocalDate>> fechasPorClave = new HashMap<>();
+
+        for (Agenda agendaActual : getItems()) {
+            String clave = construirClaveSemaforo(agendaActual);
+            if (clave == null || agendaActual.getFecha() == null) {
+                continue;
+            }
+
+            LocalDate fecha = agendaActual.getFecha().toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDate();
+
+            fechasPorClave.computeIfAbsent(clave, k -> new TreeSet<>()).add(fecha);
+        }
+
+        for (Map.Entry<String, Set<LocalDate>> entry : fechasPorClave.entrySet()) {
+            int maxRacha = 0;
+            int rachaActual = 0;
+            LocalDate fechaAnterior = null;
+
+            for (LocalDate fecha : entry.getValue()) {
+                if (fechaAnterior == null || fechaAnterior.plusDays(1).equals(fecha)) {
+                    rachaActual++;
+                } else {
+                    rachaActual = 1;
+                }
+
+                if (rachaActual > maxRacha) {
+                    maxRacha = rachaActual;
+                }
+                fechaAnterior = fecha;
+            }
+
+            rachaConsecutivaPorClaveSemaforo.put(entry.getKey(), maxRacha);
+        }
+    }
+
+    public int contarRachaConsecutivaMismaDescripcionYOrden(Agenda agenda) {
+        String clave = construirClaveSemaforo(agenda);
+        if (clave == null) {
             return 0;
         }
 
-        int cantidadReagendadas = 0;
-        List<Agenda> agendasMismoOrden = getItemsByOrder(agenda.getOrden());
-
-        for (Agenda agendaPorOrden : agendasMismoOrden) {
-            if (agendaPorOrden != null && "Reagendada".equalsIgnoreCase(agendaPorOrden.getRealizado())) {
-                cantidadReagendadas++;
-            }
-        }
-
-        return cantidadReagendadas;
+        construirCacheSemaforoPorRachasConsecutivas();
+        return rachaConsecutivaPorClaveSemaforo.getOrDefault(clave, 0);
     }
 
     public boolean mostrarSemaforoAmarillo(Agenda agenda) {
-        int cantidadReagendadas = contarReagendadasPorOrden(agenda);
-        return cantidadReagendadas > 3 && cantidadReagendadas <= 6;
+        int rachaConsecutiva = contarRachaConsecutivaMismaDescripcionYOrden(agenda);
+        return rachaConsecutiva > 3 && rachaConsecutiva <= 6;
     }
 
     public boolean mostrarSemaforoRojo(Agenda agenda) {
-        return contarReagendadasPorOrden(agenda) > 6;
+        return contarRachaConsecutivaMismaDescripcionYOrden(agenda) > 6;
     }
 
     


### PR DESCRIPTION
### Motivation
- Cambiar la lógica del semáforo para detectar repetición exacta de la `descripcion` bajo el mismo `orden` en días inmediatos consecutivos en lugar de contar el estado `Reagendada`.
- Evitar falsos positivos por el estado y mejorar la sensibilidad cuando la misma agenda se repite día a día.

### Description
- Reemplazado el conteo por estado por rachas de días consecutivos agrupando por clave `orden|descripcion.trim()` con la nueva función `construirClaveSemaforo`.
- Añadida la construcción en memoria y cache por sesión `rachaConsecutivaPorClaveSemaforo` mediante `construirCacheSemaforoPorRachasConsecutivas`, que agrupa fechas por clave y calcula la máxima racha de días inmediatos (usa `TreeSet<LocalDate>` para ordenación).
- Nuevas APIs: `contarRachaConsecutivaMismaDescripcionYOrden(Agenda)` y reutilización de `mostrarSemaforoAmarillo`/`mostrarSemaforoRojo` para evaluar la racha (`>3 && <=6` -> amarillo, `>6` -> rojo).
- Se invalida la cache cuando se recargan `items` en `getItems()` para mantener coherencia tras cambios.

### Testing
- Intenté compilar con `ant -q compile`, pero falló porque `ant` no está disponible en el entorno (`/bin/bash: ant: command not found`).
- Se realizaron búsquedas estáticas y revisión de las referencias afectadas con `rg` y `sed` para validar los puntos de integración y los cambios en el controlador.
- No se ejecutaron tests automáticos de build en este entorno por la ausencia de `ant`; el commit con los cambios fue creado correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16404af0c832781fe856a2327c89a)