### PR TITLE
Fix agenda datatable column alignment after semaphore column

### DIFF
--- a/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
+++ b/web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml
@@ -235,7 +235,7 @@
                              rendered="true"  
                              paginatorPosition="bottom"
                              filteredValue="#{agendaController.filteredAgendasConSesionOnlyAdminUsers}"
-                             
+                             tableStyle="table-layout: fixed; width: 100%;"
                              >
                     <p:poll interval="2" update="datalist" />
                     <p:ajax event="rowSelect"   update="createButton "/>
@@ -256,7 +256,7 @@
                         <h:outputText value="#{item.orden}"/>
                     </p:column>
 
-                    <p:column style="width: 20%" filterBy="#{item.apellidoNombre}" styleClass="centeredColumnContent#{item.realizado}" filterMatchMode="contains">
+                    <p:column style="width: 18%" filterBy="#{item.apellidoNombre}" styleClass="centeredColumnContent#{item.realizado}" filterMatchMode="contains">
                         <f:facet name="filter" >
                             <p:inputText id="inputApellidoYNombreEnAgenda"  onmouseout="PF('agendasTable').filter()" value="#{turnoController.apellidoYNombreSeleccionadoEnTurno}" />
                         </f:facet>
@@ -264,21 +264,21 @@
                         <h:outputText value="#{item.apellido} #{item.nombre}"/>
                     </p:column>
 
-                    <p:column id="columnToUpdate"  style="width: 20%"  filterBy="#{item.responsable}"  styleClass="centeredColumnContent#{item.realizado}"  filterMatchMode="exact">
+                    <p:column id="columnToUpdate"  style="width: 16%"  filterBy="#{item.responsable}"  styleClass="centeredColumnContent#{item.realizado}"  filterMatchMode="exact">
                         <f:facet name="filter" >
                             <p:inputText id="inputEnAgenda"  onmouseout="PF('agendasTable').filter()" value="#{turnoController.responsableSeleccionadoEnWithSessionOnlyAdmins}" />
                         </f:facet>
                         <h:outputText value="#{item.responsable}" />
                     </p:column>
                     
-                   <p:column style="text-align: center; width: 20%;" filterBy="#{item.realizado}" styleClass="centeredColumnContent#{item.getRealizado()}" filterMatchMode="exact">
+                   <p:column style="text-align: center; width: 10%;" filterBy="#{item.realizado}" styleClass="centeredColumnContent#{item.getRealizado()}" filterMatchMode="exact">
                         <f:facet name="filter" >
                             <p:inputText id="inputRealizadoEnAgenda"  onmouseout="PF('agendasTable').filter()" value="#{turnoController.realizadoSeleccionadoEnTurnoWithSessionOnlyAdmins}" />
                         </f:facet>
                        <h:outputText value="#{item.realizado}"/>
                     </p:column>
                     
-                    <p:column exportable="false" styleClass="centeredColumnContent#{item.realizado}" style="text-align: center; width: 20% ">
+                    <p:column exportable="false" styleClass="centeredColumnContent#{item.realizado}" style="text-align: center; width: 18%">
 
                         <f:facet name="header">
                             <h:outputText value="ACCIONES"/>
@@ -347,7 +347,7 @@
                                       style="display: inline-block; width: 10px; height: 10px; border-radius: 50%; background-color: #e74c3c; border: 1px solid #922b21; vertical-align: middle;" />
                     </p:column>
 
-                    <p:column style="width: 13%" styleClass="centeredColumnContent#{item.realizado}">
+                    <p:column style="width: 17%" styleClass="centeredColumnContent#{item.realizado}">
                         <f:facet name="header">
                             <h:outputText value="DESCRIPCIÓN"/>
                         </f:facet>


### PR DESCRIPTION
### Motivation
- La tabla de `AgendaListForm:datalist` quedó desalineada al agregar la columna del semáforo porque la suma de anchos excedía el 100% y el navegador recalculaba columnas en base al contenido, provocando desfase entre encabezados y celdas.
- Es necesario forzar un cálculo estable de anchos y rebalancear porcentajes para evitar que la columna de `ACCIONES` o botones anchos forcen la distribución. 

### Description
- Añadido `tableStyle="table-layout: fixed; width: 100%;"` al `p:dataTable` en `web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml` para estabilizar el cálculo de ancho de columnas.
- Rebalanceados los `style="width: ...%"` de varias columnas para que el total quede en 100% incluyendo la nueva columna `SEM.`: `Nombre` 18%, `Responsable` 16%, `Realizado` 10%, `Acciones` 18%, `SEM.` 4%, `Descripción` 17% (Fecha 10% y Orden 7% permanecen).
- No se cambiaron lógicas del backend ni componentes fuera del `p:dataTable`; es un ajuste exclusivamente de presentación en el archivo mencionado. 

### Testing
- Ejecutada la comprobación de cambios con `git diff -- web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml` y la salida confirmó las modificaciones aplicadas con éxito. 
- Realizado `git commit -m "Fix agenda datatable column alignment after semaphore column"` y la operación de commit devolvió éxito.
- Se inspeccionó el archivo modificado con `nl -ba web/agenda/List_AgendasTurnosWithSessionOnlyAdminUsers.xhtml` para verificar las líneas y estilos actualizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a02b50ec8327beb5e600970d2d3a)