### PR TITLE
Optimizar List_AgendasTurnos: LazyDataModel y consultas paginadas en backend

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
@@ -3,11 +3,14 @@ package com.estudioAlvarezVersion2.jpacontroller;
 import com.estudioAlvarezVersion2.jpa.Agenda;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -58,6 +61,56 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
         cq.select(root).orderBy(cb.asc(root.get("fecha"))); // Ordena por fecha ascendente
 
         return getEntityManager().createQuery(cq).getResultList();
+    }
+
+    public int countForLazy(Map<String, Object> filters) {
+        CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<Agenda> root = cq.from(Agenda.class);
+        cq.select(cb.count(root));
+        cq.where(buildPredicates(filters, cb, root).toArray(new Predicate[0]));
+        return getEntityManager().createQuery(cq).getSingleResult().intValue();
+    }
+
+    public List<Agenda> findForLazy(int first, int pageSize, String sortField, boolean ascending, Map<String, Object> filters) {
+        CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();
+        CriteriaQuery<Agenda> cq = cb.createQuery(Agenda.class);
+        Root<Agenda> root = cq.from(Agenda.class);
+        cq.select(root);
+        cq.where(buildPredicates(filters, cb, root).toArray(new Predicate[0]));
+
+        String safeSortField = (sortField == null || sortField.trim().isEmpty()) ? "fecha" : sortField;
+        cq.orderBy(ascending ? cb.asc(root.get(safeSortField)) : cb.desc(root.get(safeSortField)));
+
+        return getEntityManager().createQuery(cq)
+                .setFirstResult(first)
+                .setMaxResults(pageSize)
+                .getResultList();
+    }
+
+    private List<Predicate> buildPredicates(Map<String, Object> filters, CriteriaBuilder cb, Root<Agenda> root) {
+        List<Predicate> predicates = new java.util.ArrayList<>();
+        if (filters == null) {
+            return predicates;
+        }
+        for (Map.Entry<String, Object> entry : filters.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value == null || String.valueOf(value).trim().isEmpty()) {
+                continue;
+            }
+            String text = String.valueOf(value).trim();
+            if ("diaMesAnio".equals(key)) {
+                Expression<String> fechaFormateada = cb.function("DATE_FORMAT", String.class, root.get("fecha"), cb.literal("%d/%m/%Y"));
+                predicates.add(cb.equal(fechaFormateada, text));
+            } else if ("apellidoNombre".equals(key)) {
+                Expression<String> apellidoNombre = cb.concat(cb.concat(cb.coalesce(root.<String>get("apellido"), ""), " "), cb.coalesce(root.<String>get("nombre"), ""));
+                predicates.add(cb.like(cb.lower(apellidoNombre), "%" + text.toLowerCase() + "%"));
+            } else {
+                predicates.add(cb.equal(root.get(key), value));
+            }
+        }
+        return predicates;
     }
     
 }

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
@@ -79,7 +79,7 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
         cq.select(root);
         cq.where(buildPredicates(filters, cb, root).toArray(new Predicate[0]));
 
-        String safeSortField = (sortField == null || sortField.trim().isEmpty()) ? "fecha" : sortField;
+        String safeSortField = mapSortField(sortField);
         cq.orderBy(ascending ? cb.asc(root.get(safeSortField)) : cb.desc(root.get(safeSortField)));
 
         return getEntityManager().createQuery(cq)
@@ -102,7 +102,7 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
             String text = String.valueOf(value).trim();
             if ("diaMesAnio".equals(key)) {
                 Expression<String> fechaFormateada = cb.function("DATE_FORMAT", String.class, root.get("fecha"), cb.literal("%d/%m/%Y"));
-                predicates.add(cb.equal(fechaFormateada, text));
+                predicates.add(cb.like(fechaFormateada, text + "%"));
             } else if ("apellidoNombre".equals(key)) {
                 Expression<String> apellidoNombre = cb.concat(cb.concat(cb.coalesce(root.<String>get("apellido"), ""), " "), cb.coalesce(root.<String>get("nombre"), ""));
                 predicates.add(cb.like(cb.lower(apellidoNombre), "%" + text.toLowerCase() + "%"));
@@ -111,6 +111,16 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
             }
         }
         return predicates;
+    }
+
+    private String mapSortField(String sortField) {
+        if (sortField == null || sortField.trim().isEmpty() || "diaMesAnio".equals(sortField)) {
+            return "fecha";
+        }
+        if ("apellidoNombre".equals(sortField)) {
+            return "apellido";
+        }
+        return sortField;
     }
     
 }

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
@@ -7,11 +7,14 @@ package com.estudioAlvarezVersion2.jpacontroller;
 
 import com.estudioAlvarezVersion2.jpa.Turno;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -70,6 +73,56 @@ public class TurnoFacade extends AbstractFacade<Turno> {
         TypedQuery<Turno> query = em.createNamedQuery("Turno.findByOrder", Turno.class);
         query.setParameter("orden", orden);
         return query.getResultList();
+    }
+
+    public int countForLazy(Map<String, Object> filters) {
+        CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<Turno> root = cq.from(Turno.class);
+        cq.select(cb.count(root));
+        cq.where(buildPredicates(filters, cb, root).toArray(new Predicate[0]));
+        return getEntityManager().createQuery(cq).getSingleResult().intValue();
+    }
+
+    public List<Turno> findForLazy(int first, int pageSize, String sortField, boolean ascending, Map<String, Object> filters) {
+        CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();
+        CriteriaQuery<Turno> cq = cb.createQuery(Turno.class);
+        Root<Turno> root = cq.from(Turno.class);
+        cq.select(root);
+        cq.where(buildPredicates(filters, cb, root).toArray(new Predicate[0]));
+
+        String safeSortField = (sortField == null || sortField.trim().isEmpty()) ? "horaYDia" : sortField;
+        cq.orderBy(ascending ? cb.asc(root.get(safeSortField)) : cb.desc(root.get(safeSortField)));
+
+        return getEntityManager().createQuery(cq)
+                .setFirstResult(first)
+                .setMaxResults(pageSize)
+                .getResultList();
+    }
+
+    private List<Predicate> buildPredicates(Map<String, Object> filters, CriteriaBuilder cb, Root<Turno> root) {
+        List<Predicate> predicates = new java.util.ArrayList<>();
+        if (filters == null) {
+            return predicates;
+        }
+        for (Map.Entry<String, Object> entry : filters.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value == null || String.valueOf(value).trim().isEmpty()) {
+                continue;
+            }
+            String text = String.valueOf(value).trim();
+            if ("diaMesAnio".equals(key)) {
+                Expression<String> fechaFormateada = cb.function("DATE_FORMAT", String.class, root.get("horaYDia"), cb.literal("%d/%m/%Y"));
+                predicates.add(cb.equal(fechaFormateada, text));
+            } else if ("apellidoNombre".equals(key)) {
+                Expression<String> apellidoNombre = cb.concat(cb.concat(cb.coalesce(root.<String>get("apellido"), ""), " "), cb.coalesce(root.<String>get("nombre"), ""));
+                predicates.add(cb.like(cb.lower(apellidoNombre), "%" + text.toLowerCase() + "%"));
+            } else {
+                predicates.add(cb.equal(root.get(key), value));
+            }
+        }
+        return predicates;
     }
     
 }

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
@@ -91,7 +91,7 @@ public class TurnoFacade extends AbstractFacade<Turno> {
         cq.select(root);
         cq.where(buildPredicates(filters, cb, root).toArray(new Predicate[0]));
 
-        String safeSortField = (sortField == null || sortField.trim().isEmpty()) ? "horaYDia" : sortField;
+        String safeSortField = mapSortField(sortField);
         cq.orderBy(ascending ? cb.asc(root.get(safeSortField)) : cb.desc(root.get(safeSortField)));
 
         return getEntityManager().createQuery(cq)
@@ -114,7 +114,7 @@ public class TurnoFacade extends AbstractFacade<Turno> {
             String text = String.valueOf(value).trim();
             if ("diaMesAnio".equals(key)) {
                 Expression<String> fechaFormateada = cb.function("DATE_FORMAT", String.class, root.get("horaYDia"), cb.literal("%d/%m/%Y"));
-                predicates.add(cb.equal(fechaFormateada, text));
+                predicates.add(cb.like(fechaFormateada, text + "%"));
             } else if ("apellidoNombre".equals(key)) {
                 Expression<String> apellidoNombre = cb.concat(cb.concat(cb.coalesce(root.<String>get("apellido"), ""), " "), cb.coalesce(root.<String>get("nombre"), ""));
                 predicates.add(cb.like(cb.lower(apellidoNombre), "%" + text.toLowerCase() + "%"));
@@ -123,6 +123,16 @@ public class TurnoFacade extends AbstractFacade<Turno> {
             }
         }
         return predicates;
+    }
+
+    private String mapSortField(String sortField) {
+        if (sortField == null || sortField.trim().isEmpty() || "diaMesAnio".equals(sortField)) {
+            return "horaYDia";
+        }
+        if ("apellidoNombre".equals(sortField)) {
+            return "apellido";
+        }
+        return sortField;
     }
     
 }

--- a/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
@@ -57,6 +57,8 @@ import javax.servlet.http.HttpSession;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.context.RequestContext;
 import org.primefaces.event.SelectEvent;
+import org.primefaces.model.LazyDataModel;
+import org.primefaces.model.SortOrder;
 
 
 
@@ -71,6 +73,7 @@ public class AgendaController implements Serializable {
     private EntityManager em;
 
     private List<Agenda> items = null;
+    private LazyDataModel<Agenda> lazyItems;
     private List<Agenda> itemsitemsWithSession = null;
     private transient Map<String, Integer> rachaConsecutivaPorClaveSemaforo = null;
     
@@ -1277,6 +1280,21 @@ public class AgendaController implements Serializable {
         //cloned_list = new ArrayList<>(this.items);
         //Collections.sort(cloned_list, new SortByDate());
         return items;
+    }
+
+    public LazyDataModel<Agenda> getLazyItems() {
+        if (lazyItems == null) {
+            lazyItems = new LazyDataModel<Agenda>() {
+                @Override
+                public List<Agenda> load(int first, int pageSize, String sortField, SortOrder sortOrder, Map<String, Object> filters) {
+                    boolean ascending = sortOrder == null || SortOrder.ASCENDING.equals(sortOrder);
+                    int total = getFacade().countForLazy(filters);
+                    setRowCount(total);
+                    return getFacade().findForLazy(first, pageSize, sortField, ascending, filters);
+                }
+            };
+        }
+        return lazyItems;
     }
 
     public List<String> completeDescripcionAgenda(String query) {

--- a/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
@@ -35,6 +35,8 @@ import javax.faces.convert.FacesConverter;
 import javax.servlet.http.HttpSession;
 import org.primefaces.context.RequestContext;
 import org.primefaces.event.SelectEvent;
+import org.primefaces.model.LazyDataModel;
+import org.primefaces.model.SortOrder;
 
 /**
  *
@@ -47,6 +49,7 @@ public class TurnoController implements Serializable {
     @EJB
     private com.estudioAlvarezVersion2.jpacontroller.TurnoFacade ejbFacade;
     private List<Turno> items = null;
+    private LazyDataModel<Turno> lazyItems;
     private Turno selected;
 
     private Turno selectedTurnoPasado;
@@ -468,6 +471,21 @@ public class TurnoController implements Serializable {
             items = getFacade().findAllSortedByDate();
         }
         return items; 
+    }
+
+    public LazyDataModel<Turno> getLazyItems() {
+        if (lazyItems == null) {
+            lazyItems = new LazyDataModel<Turno>() {
+                @Override
+                public List<Turno> load(int first, int pageSize, String sortField, SortOrder sortOrder, Map<String, Object> filters) {
+                    boolean ascending = sortOrder == null || SortOrder.ASCENDING.equals(sortOrder);
+                    int total = getFacade().countForLazy(filters);
+                    setRowCount(total);
+                    return getFacade().findForLazy(first, pageSize, sortField, ascending, filters);
+                }
+            };
+        }
+        return lazyItems;
     }
 
     private void addConflictWarningsOnCreate(Turno turnoToCreate) {

--- a/web/agenda/List_AgendasTurnos.xhtml
+++ b/web/agenda/List_AgendasTurnos.xhtml
@@ -41,9 +41,10 @@
 
                 <br></br><br></br>
 
-                <p:dataTable id="datalist" value="#{turnoController.items}" var="item"
+                <p:dataTable id="datalist" value="#{turnoController.lazyItems}" var="item"
                              selectionMode="single" selection="#{turnoController.selected}"
                              paginator="true"
+                             lazy="true"
                              rowKey="#{item.idTurno}"
                              widgetVar="turnosTable"
                              rows="20"
@@ -175,10 +176,11 @@
 
             <h:form id="AgendaListForm" style="background-color: #F4F8FA">
 
-                <p:dataTable id="datalist" value="#{agendaController.items}" var="item"
+                <p:dataTable id="datalist" value="#{agendaController.lazyItems}" var="item"
                              selectionMode="single" selection="#{agendaController.selected}"
                              rowKey="#{item.idAgenda}"
                              paginator="true"
+                             lazy="true"
                              rows="50"
                              widgetVar="agendasTable"
                              rowsPerPageTemplate="100,200,500"


### PR DESCRIPTION
### Motivation
- La vista `List_AgendasTurnos.xhtml` estaba cargando las listas completas desde los getters `getItems()` de `AgendaController` y `TurnoController` (que llaman a `findAllSortedByDate()`), provocando HTML masivo y tiempos de carga altos con 130k+ registros. 
- Objetivo reducir el tiempo de carga inicial a <2s evitando traer/renderizar todos los registros y aplicando paginación real en base de datos. 
- Mantener comportamiento de filtros y ordenamiento y compatibilidad con PrimeFaces 5 y la lógica existente de creación/edición/borrado.

### Description
- Migración de las dos tablas en `web/agenda/List_AgendasTurnos.xhtml` para usar `lazy=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c3cafb808327a42d9d2cf448e183)