### PR TITLE
Piloto: paginación server-side con `LazyDataModel` para Agenda/Turno

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
@@ -3,10 +3,12 @@ package com.estudioAlvarezVersion2.jpacontroller;
 import com.estudioAlvarezVersion2.jpa.Agenda;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -51,6 +53,87 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
              .getResultList();
     }
     
+
+    public List<Agenda> findRangeLazy(int first, int pageSize, String sortField, boolean ascending, Map<String, Object> filters) {
+        StringBuilder jpql = new StringBuilder("SELECT a FROM Agenda a WHERE 1=1");
+        appendLazyFilters(jpql, filters);
+        jpql.append(" ORDER BY ");
+        if ("orden".equals(sortField)) {
+            jpql.append("a.orden");
+        } else if ("apellidoNombre".equals(sortField)) {
+            jpql.append("a.apellido, a.nombre");
+        } else if ("responsable".equals(sortField)) {
+            jpql.append("a.responsable");
+        } else if ("realizado".equals(sortField)) {
+            jpql.append("a.realizado");
+        } else {
+            jpql.append("a.fecha");
+        }
+        jpql.append(ascending ? " ASC" : " DESC");
+        jpql.append(", a.idAgenda DESC");
+
+        Query q = em.createQuery(jpql.toString());
+        setLazyFilterParameters(q, filters);
+        q.setFirstResult(first);
+        q.setMaxResults(pageSize);
+        return q.getResultList();
+    }
+
+    public int countLazy(Map<String, Object> filters) {
+        StringBuilder jpql = new StringBuilder("SELECT COUNT(a) FROM Agenda a WHERE 1=1");
+        appendLazyFilters(jpql, filters);
+        Query q = em.createQuery(jpql.toString());
+        setLazyFilterParameters(q, filters);
+        return ((Long) q.getSingleResult()).intValue();
+    }
+
+    private void appendLazyFilters(StringBuilder jpql, Map<String, Object> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return;
+        }
+        if (hasFilter(filters, "diaMesAnio")) {
+            jpql.append(" AND FUNCTION('DATE_FORMAT', a.fecha, '%d/%m/%Y') LIKE :diaMesAnio");
+        }
+        if (hasFilter(filters, "orden")) {
+            jpql.append(" AND CAST(a.orden AS string) LIKE :orden");
+        }
+        if (hasFilter(filters, "apellidoNombre")) {
+            jpql.append(" AND LOWER(CONCAT(COALESCE(a.apellido,''), ' ', COALESCE(a.nombre,''))) LIKE :apellidoNombre");
+        }
+        if (hasFilter(filters, "responsable")) {
+            jpql.append(" AND LOWER(a.responsable) LIKE :responsable");
+        }
+        if (hasFilter(filters, "realizado")) {
+            jpql.append(" AND LOWER(a.realizado) LIKE :realizado");
+        }
+    }
+
+    private void setLazyFilterParameters(Query query, Map<String, Object> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return;
+        }
+        if (hasFilter(filters, "diaMesAnio")) {
+            query.setParameter("diaMesAnio", "%" + String.valueOf(filters.get("diaMesAnio")).trim() + "%");
+        }
+        if (hasFilter(filters, "orden")) {
+            query.setParameter("orden", "%" + String.valueOf(filters.get("orden")).trim() + "%");
+        }
+        if (hasFilter(filters, "apellidoNombre")) {
+            query.setParameter("apellidoNombre", "%" + String.valueOf(filters.get("apellidoNombre")).trim().toLowerCase() + "%");
+        }
+        if (hasFilter(filters, "responsable")) {
+            query.setParameter("responsable", "%" + String.valueOf(filters.get("responsable")).trim().toLowerCase() + "%");
+        }
+        if (hasFilter(filters, "realizado")) {
+            query.setParameter("realizado", "%" + String.valueOf(filters.get("realizado")).trim().toLowerCase() + "%");
+        }
+    }
+
+    private boolean hasFilter(Map<String, Object> filters, String key) {
+        Object value = filters.get(key);
+        return value != null && !String.valueOf(value).trim().isEmpty();
+    }
+
     public List<Agenda> findAllSortedByDate() {
         CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();
         CriteriaQuery<Agenda> cq = cb.createQuery(Agenda.class);

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/AgendaFacade.java
@@ -1,6 +1,9 @@
 package com.estudioAlvarezVersion2.jpacontroller;
 
 import com.estudioAlvarezVersion2.jpa.Agenda;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -92,10 +95,10 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
             return;
         }
         if (hasFilter(filters, "diaMesAnio")) {
-            jpql.append(" AND FUNCTION('DATE_FORMAT', a.fecha, '%d/%m/%Y') LIKE :diaMesAnio");
+            jpql.append(" AND a.fecha >= :fechaDesde AND a.fecha < :fechaHasta");
         }
         if (hasFilter(filters, "orden")) {
-            jpql.append(" AND CAST(a.orden AS string) LIKE :orden");
+            jpql.append(" AND a.orden = :orden");
         }
         if (hasFilter(filters, "apellidoNombre")) {
             jpql.append(" AND LOWER(CONCAT(COALESCE(a.apellido,''), ' ', COALESCE(a.nombre,''))) LIKE :apellidoNombre");
@@ -113,10 +116,17 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
             return;
         }
         if (hasFilter(filters, "diaMesAnio")) {
-            query.setParameter("diaMesAnio", "%" + String.valueOf(filters.get("diaMesAnio")).trim() + "%");
+            Date[] rangoFecha = parseDateFilter(String.valueOf(filters.get("diaMesAnio")));
+            if (rangoFecha != null) {
+                query.setParameter("fechaDesde", rangoFecha[0]);
+                query.setParameter("fechaHasta", rangoFecha[1]);
+            }
         }
         if (hasFilter(filters, "orden")) {
-            query.setParameter("orden", "%" + String.valueOf(filters.get("orden")).trim() + "%");
+            Integer orden = parseIntegerFilter(filters.get("orden"));
+            if (orden != null) {
+                query.setParameter("orden", orden);
+            }
         }
         if (hasFilter(filters, "apellidoNombre")) {
             query.setParameter("apellidoNombre", "%" + String.valueOf(filters.get("apellidoNombre")).trim().toLowerCase() + "%");
@@ -131,7 +141,51 @@ public class AgendaFacade extends AbstractFacade<Agenda> {
 
     private boolean hasFilter(Map<String, Object> filters, String key) {
         Object value = filters.get(key);
-        return value != null && !String.valueOf(value).trim().isEmpty();
+        if (value == null || String.valueOf(value).trim().isEmpty()) {
+            return false;
+        }
+        if ("orden".equals(key)) {
+            return parseIntegerFilter(value) != null;
+        }
+        if ("diaMesAnio".equals(key)) {
+            return parseDateFilter(String.valueOf(value)) != null;
+        }
+        return true;
+    }
+
+    private Integer parseIntegerFilter(Object value) {
+        try {
+            return Integer.valueOf(String.valueOf(value).trim());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private Date[] parseDateFilter(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty() || trimmed.length() != 10) {
+            return null;
+        }
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        sdf.setLenient(false);
+        try {
+            Date date = sdf.parse(trimmed);
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(date);
+            cal.set(Calendar.HOUR_OF_DAY, 0);
+            cal.set(Calendar.MINUTE, 0);
+            cal.set(Calendar.SECOND, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+            Date from = cal.getTime();
+            cal.add(Calendar.DATE, 1);
+            Date to = cal.getTime();
+            return new Date[]{from, to};
+        } catch (ParseException ex) {
+            return null;
+        }
     }
 
     public List<Agenda> findAllSortedByDate() {

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
@@ -7,10 +7,12 @@ package com.estudioAlvarezVersion2.jpacontroller;
 
 import com.estudioAlvarezVersion2.jpa.Turno;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -56,6 +58,63 @@ public class TurnoFacade extends AbstractFacade<Turno> {
                              .getResultList();
     }
     
+
+
+    public List<Turno> findRangeLazy(int first, int pageSize, String sortField, boolean ascending, Map<String, Object> filters) {
+        StringBuilder jpql = new StringBuilder("SELECT t FROM Turno t WHERE 1=1");
+        appendLazyFilters(jpql, filters);
+        jpql.append(" ORDER BY ");
+        if ("orden".equals(sortField)) {
+            jpql.append("t.orden");
+        } else if ("apellidoNombre".equals(sortField)) {
+            jpql.append("t.apellido, t.nombre");
+        } else if ("responsable".equals(sortField)) {
+            jpql.append("t.responsable");
+        } else if ("realizado".equals(sortField)) {
+            jpql.append("t.realizado");
+        } else {
+            jpql.append("t.horaYDia");
+        }
+        jpql.append(ascending ? " ASC" : " DESC");
+        jpql.append(", t.idTurno DESC");
+
+        Query q = em.createQuery(jpql.toString());
+        setLazyFilterParameters(q, filters);
+        q.setFirstResult(first);
+        q.setMaxResults(pageSize);
+        return q.getResultList();
+    }
+
+    public int countLazy(Map<String, Object> filters) {
+        StringBuilder jpql = new StringBuilder("SELECT COUNT(t) FROM Turno t WHERE 1=1");
+        appendLazyFilters(jpql, filters);
+        Query q = em.createQuery(jpql.toString());
+        setLazyFilterParameters(q, filters);
+        return ((Long) q.getSingleResult()).intValue();
+    }
+
+    private void appendLazyFilters(StringBuilder jpql, Map<String, Object> filters) {
+        if (filters == null || filters.isEmpty()) return;
+        if (hasFilter(filters, "diaMesAnio")) jpql.append(" AND FUNCTION('DATE_FORMAT', t.horaYDia, '%d/%m/%Y') LIKE :diaMesAnio");
+        if (hasFilter(filters, "orden")) jpql.append(" AND CAST(t.orden AS string) LIKE :orden");
+        if (hasFilter(filters, "apellidoNombre")) jpql.append(" AND LOWER(CONCAT(COALESCE(t.apellido,''), ' ', COALESCE(t.nombre,''))) LIKE :apellidoNombre");
+        if (hasFilter(filters, "responsable")) jpql.append(" AND LOWER(t.responsable) LIKE :responsable");
+        if (hasFilter(filters, "realizado")) jpql.append(" AND LOWER(t.realizado) LIKE :realizado");
+    }
+
+    private void setLazyFilterParameters(Query query, Map<String, Object> filters) {
+        if (filters == null || filters.isEmpty()) return;
+        if (hasFilter(filters, "diaMesAnio")) query.setParameter("diaMesAnio", "%" + String.valueOf(filters.get("diaMesAnio")).trim() + "%");
+        if (hasFilter(filters, "orden")) query.setParameter("orden", "%" + String.valueOf(filters.get("orden")).trim() + "%");
+        if (hasFilter(filters, "apellidoNombre")) query.setParameter("apellidoNombre", "%" + String.valueOf(filters.get("apellidoNombre")).trim().toLowerCase() + "%");
+        if (hasFilter(filters, "responsable")) query.setParameter("responsable", "%" + String.valueOf(filters.get("responsable")).trim().toLowerCase() + "%");
+        if (hasFilter(filters, "realizado")) query.setParameter("realizado", "%" + String.valueOf(filters.get("realizado")).trim().toLowerCase() + "%");
+    }
+
+    private boolean hasFilter(Map<String, Object> filters, String key) {
+        Object value = filters.get(key);
+        return value != null && !String.valueOf(value).trim().isEmpty();
+    }
 
     public List<Turno> findAllSortedByDate() {
         CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/TurnoFacade.java
@@ -6,6 +6,10 @@
 package com.estudioAlvarezVersion2.jpacontroller;
 
 import com.estudioAlvarezVersion2.jpa.Turno;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,8 +99,8 @@ public class TurnoFacade extends AbstractFacade<Turno> {
 
     private void appendLazyFilters(StringBuilder jpql, Map<String, Object> filters) {
         if (filters == null || filters.isEmpty()) return;
-        if (hasFilter(filters, "diaMesAnio")) jpql.append(" AND FUNCTION('DATE_FORMAT', t.horaYDia, '%d/%m/%Y') LIKE :diaMesAnio");
-        if (hasFilter(filters, "orden")) jpql.append(" AND CAST(t.orden AS string) LIKE :orden");
+        if (hasFilter(filters, "diaMesAnio")) jpql.append(" AND t.horaYDia >= :fechaDesde AND t.horaYDia < :fechaHasta");
+        if (hasFilter(filters, "orden")) jpql.append(" AND t.orden = :orden");
         if (hasFilter(filters, "apellidoNombre")) jpql.append(" AND LOWER(CONCAT(COALESCE(t.apellido,''), ' ', COALESCE(t.nombre,''))) LIKE :apellidoNombre");
         if (hasFilter(filters, "responsable")) jpql.append(" AND LOWER(t.responsable) LIKE :responsable");
         if (hasFilter(filters, "realizado")) jpql.append(" AND LOWER(t.realizado) LIKE :realizado");
@@ -104,8 +108,19 @@ public class TurnoFacade extends AbstractFacade<Turno> {
 
     private void setLazyFilterParameters(Query query, Map<String, Object> filters) {
         if (filters == null || filters.isEmpty()) return;
-        if (hasFilter(filters, "diaMesAnio")) query.setParameter("diaMesAnio", "%" + String.valueOf(filters.get("diaMesAnio")).trim() + "%");
-        if (hasFilter(filters, "orden")) query.setParameter("orden", "%" + String.valueOf(filters.get("orden")).trim() + "%");
+        if (hasFilter(filters, "diaMesAnio")) {
+            Date[] rangoFecha = parseDateFilter(String.valueOf(filters.get("diaMesAnio")));
+            if (rangoFecha != null) {
+                query.setParameter("fechaDesde", rangoFecha[0]);
+                query.setParameter("fechaHasta", rangoFecha[1]);
+            }
+        }
+        if (hasFilter(filters, "orden")) {
+            Integer orden = parseIntegerFilter(filters.get("orden"));
+            if (orden != null) {
+                query.setParameter("orden", orden);
+            }
+        }
         if (hasFilter(filters, "apellidoNombre")) query.setParameter("apellidoNombre", "%" + String.valueOf(filters.get("apellidoNombre")).trim().toLowerCase() + "%");
         if (hasFilter(filters, "responsable")) query.setParameter("responsable", "%" + String.valueOf(filters.get("responsable")).trim().toLowerCase() + "%");
         if (hasFilter(filters, "realizado")) query.setParameter("realizado", "%" + String.valueOf(filters.get("realizado")).trim().toLowerCase() + "%");
@@ -113,7 +128,51 @@ public class TurnoFacade extends AbstractFacade<Turno> {
 
     private boolean hasFilter(Map<String, Object> filters, String key) {
         Object value = filters.get(key);
-        return value != null && !String.valueOf(value).trim().isEmpty();
+        if (value == null || String.valueOf(value).trim().isEmpty()) {
+            return false;
+        }
+        if ("orden".equals(key)) {
+            return parseIntegerFilter(value) != null;
+        }
+        if ("diaMesAnio".equals(key)) {
+            return parseDateFilter(String.valueOf(value)) != null;
+        }
+        return true;
+    }
+
+    private Integer parseIntegerFilter(Object value) {
+        try {
+            return Integer.valueOf(String.valueOf(value).trim());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private Date[] parseDateFilter(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty() || trimmed.length() != 10) {
+            return null;
+        }
+        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        sdf.setLenient(false);
+        try {
+            Date date = sdf.parse(trimmed);
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(date);
+            cal.set(Calendar.HOUR_OF_DAY, 0);
+            cal.set(Calendar.MINUTE, 0);
+            cal.set(Calendar.SECOND, 0);
+            cal.set(Calendar.MILLISECOND, 0);
+            Date from = cal.getTime();
+            cal.add(Calendar.DATE, 1);
+            Date to = cal.getTime();
+            return new Date[]{from, to};
+        } catch (ParseException ex) {
+            return null;
+        }
     }
 
     public List<Turno> findAllSortedByDate() {

--- a/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/AgendaController.java
@@ -56,6 +56,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.context.RequestContext;
+import org.primefaces.model.LazyDataModel;
+import org.primefaces.model.SortOrder;
 import org.primefaces.event.SelectEvent;
 
 
@@ -71,6 +73,8 @@ public class AgendaController implements Serializable {
     private EntityManager em;
 
     private List<Agenda> items = null;
+    private LazyDataModel<Agenda> lazyModel;
+    private List<Agenda> currentPageData = new ArrayList<Agenda>();
     private List<Agenda> itemsitemsWithSession = null;
     private transient Map<String, Integer> rachaConsecutivaPorClaveSemaforo = null;
     
@@ -1265,6 +1269,51 @@ public class AgendaController implements Serializable {
             selectedAgendaPasada = null; // Remove selection
             items = null;    // Invalidate list of items to trigger re-query.
         }
+    }
+
+
+    public LazyDataModel<Agenda> getLazyModel() {
+        if (lazyModel == null) {
+            initLazyModel();
+        }
+        return lazyModel;
+    }
+
+    private void initLazyModel() {
+        lazyModel = new LazyDataModel<Agenda>() {
+            @Override
+            public List<Agenda> load(int first, int pageSize, String sortField, SortOrder sortOrder, Map<String, Object> filters) {
+                if (filters == null) {
+                    filters = new HashMap<String, Object>();
+                }
+                boolean ascending = sortOrder == null || SortOrder.ASCENDING.equals(sortOrder) || SortOrder.UNSORTED.equals(sortOrder);
+                currentPageData = getFacade().findRangeLazy(first, pageSize, sortField, ascending, filters);
+                setRowCount(getFacade().countLazy(filters));
+                return currentPageData;
+            }
+
+            @Override
+            public Object getRowKey(Agenda item) {
+                return item != null ? item.getIdAgenda() : null;
+            }
+
+            @Override
+            public Agenda getRowData(String rowKey) {
+                if (rowKey == null || rowKey.trim().isEmpty()) {
+                    return null;
+                }
+                for (Agenda item : currentPageData) {
+                    if (item != null && item.getIdAgenda() != null && rowKey.equals(String.valueOf(item.getIdAgenda()))) {
+                        return item;
+                    }
+                }
+                try {
+                    return getFacade().find(Integer.valueOf(rowKey));
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            }
+        };
     }
 
     public List<Agenda> getItems() {

--- a/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/TurnoController.java
@@ -34,6 +34,8 @@ import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
 import javax.servlet.http.HttpSession;
 import org.primefaces.context.RequestContext;
+import org.primefaces.model.LazyDataModel;
+import org.primefaces.model.SortOrder;
 import org.primefaces.event.SelectEvent;
 
 /**
@@ -47,6 +49,8 @@ public class TurnoController implements Serializable {
     @EJB
     private com.estudioAlvarezVersion2.jpacontroller.TurnoFacade ejbFacade;
     private List<Turno> items = null;
+    private LazyDataModel<Turno> lazyModel;
+    private List<Turno> currentPageData = new ArrayList<Turno>();
     private Turno selected;
 
     private Turno selectedTurnoPasado;
@@ -461,6 +465,51 @@ public class TurnoController implements Serializable {
              filteredTurnosConSesion = null;
              filteredturnos = null;
         }
+    }
+
+
+    public LazyDataModel<Turno> getLazyModel() {
+        if (lazyModel == null) {
+            initLazyModel();
+        }
+        return lazyModel;
+    }
+
+    private void initLazyModel() {
+        lazyModel = new LazyDataModel<Turno>() {
+            @Override
+            public List<Turno> load(int first, int pageSize, String sortField, SortOrder sortOrder, Map<String, Object> filters) {
+                if (filters == null) {
+                    filters = new HashMap<String, Object>();
+                }
+                boolean ascending = sortOrder == null || SortOrder.ASCENDING.equals(sortOrder) || SortOrder.UNSORTED.equals(sortOrder);
+                currentPageData = getFacade().findRangeLazy(first, pageSize, sortField, ascending, filters);
+                setRowCount(getFacade().countLazy(filters));
+                return currentPageData;
+            }
+
+            @Override
+            public Object getRowKey(Turno item) {
+                return item != null ? item.getIdTurno() : null;
+            }
+
+            @Override
+            public Turno getRowData(String rowKey) {
+                if (rowKey == null || rowKey.trim().isEmpty()) {
+                    return null;
+                }
+                for (Turno item : currentPageData) {
+                    if (item != null && item.getIdTurno() != null && rowKey.equals(String.valueOf(item.getIdTurno()))) {
+                        return item;
+                    }
+                }
+                try {
+                    return getFacade().find(Integer.valueOf(rowKey));
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            }
+        };
     }
 
     public List<Turno> getItems() {

--- a/web/agenda/List_AgendasTurnos.xhtml
+++ b/web/agenda/List_AgendasTurnos.xhtml
@@ -41,9 +41,10 @@
 
                 <br></br><br></br>
 
-                <p:dataTable id="datalist" value="#{turnoController.items}" var="item"
+                <p:dataTable id="datalist" value="#{turnoController.lazyModel}" var="item"
                              selectionMode="single" selection="#{turnoController.selected}"
                              paginator="true"
+                             lazy="true"
                              rowKey="#{item.idTurno}"
                              widgetVar="turnosTable"
                              rows="20"
@@ -175,10 +176,11 @@
 
             <h:form id="AgendaListForm" style="background-color: #F4F8FA">
 
-                <p:dataTable id="datalist" value="#{agendaController.items}" var="item"
+                <p:dataTable id="datalist" value="#{agendaController.lazyModel}" var="item"
                              selectionMode="single" selection="#{agendaController.selected}"
                              rowKey="#{item.idAgenda}"
                              paginator="true"
+                             lazy="true"
                              rows="50"
                              widgetVar="agendasTable"
                              rowsPerPageTemplate="100,200,500"


### PR DESCRIPTION
### Motivation
- Evitar que las pantallas `Agenda`/`Turno` carguen todos los registros en memoria y provocar lentitud o OOM, migrando a paginación real server-side compatible con la versión de PrimeFaces del proyecto. 
- Hacer una migración segura e incremental, conservando filtros, selección, `rowKey`, acciones CRUD, diálogos y exportadores mientras se valida el patrón. 

### Description
- Se añadieron en `AgendaFacade` y `TurnoFacade` los métodos `findRangeLazy(int first, int pageSize, String sortField, boolean ascending, Map<String,Object> filters)` y `countLazy(Map<String,Object> filters)` que usan consultas parametrizadas, `setFirstResult`/`setMaxResults` y un `ORDER BY` estable con fallback por fecha/hora e `id DESC` para paginación consistente. 
- Se implementaron filtros parametrizados seguros (sin concatenación directa de input) y soporte para los filtros usados en las tablas (`diaMesAnio`, `orden`, `apellidoNombre`, `responsable`, `realizado`), preparando parámetros con `Query.setParameter(...)`. 
- Se incorporó `LazyDataModel<Turno>` y `LazyDataModel<Agenda>` en `TurnoController` y `AgendaController` respectivamente, con `load(...)`, `getRowKey(...)` y `getRowData(...)` (incluye fallback a `find(id)` para selección entre páginas). 
- Se modificó la vista piloto `web/agenda/List_AgendasTurnos.xhtml` para usar `value="#{turnoController.lazyModel}"` y `value="#{agendaController.lazyModel}"` y se añadió `lazy="true"` en ambas `p:dataTable` sin tocar `rowKey`, `selection`, botones, diálogos ni `filteredValue`; los `dataExporter` mantienen `pageOnly="true"`. 

### Testing
- Búsqueda de tablas candidatas realizada con expresiones `rg`/search para localizar `p:dataTable` con `paginator="true"` y `value` apuntando a `*Controller.items`, y se confirmaron las pantallas piloto (`agenda/List_AgendasTurnos.xhtml`) como primera candidata; la búsqueda tuvo éxito. 
- Inspección del diff de los ficheros modificados (`AgendaFacade`, `TurnoFacade`, `AgendaController`, `TurnoController`, `web/agenda/List_AgendasTurnos.xhtml`) y revisión de los fragmentos generados para verificar firmas de `LazyDataModel.load`, `getRowKey` y `getRowData`; la verificación está OK. 
- Intento de compilación automática con `ant -q compile` falló por falta de `ant` en el entorno (no se pudo realizar build automático aquí), por lo que la validación de ejecución debe hacerse en el entorno de despliegue con app server y `ant`/build instalado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f59eed09248327ba2dee9b8d7269bf)