### PR TITLE
Agregar agendas predeterminadas al crear fechas judiciales de sentencia

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
@@ -1,6 +1,8 @@
 package com.estudioAlvarezVersion2.jsf;
 
 import com.estudioAlvarezVersion2.jpa.EventoDeCausasJudiciales;
+import com.estudioAlvarezVersion2.jpa.Agenda;
+import com.estudioAlvarezVersion2.jpacontroller.AgendaFacade;
 import com.estudioAlvarezVersion2.jpacontroller.EventoDeCausasJudicialesFacade;
 import com.estudioAlvarezVersion2.jsf.util.JsfUtil;
 import javax.ejb.EJB;
@@ -8,7 +10,11 @@ import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -28,9 +34,13 @@ public class EventoDeCausasJudicialesController implements Serializable {
 
     @EJB
     private EventoDeCausasJudicialesFacade ejbFacade;
+    @EJB
+    private AgendaFacade agendaFacade;
     private List<EventoDeCausasJudiciales> items = null;
     private EventoDeCausasJudiciales selected;
     private EventoDeCausasJudiciales selectedParaEventoJudicialNuevo;
+    private List<SugerenciaAgendaJudicial> agendasSugeridas = new ArrayList<>();
+    private boolean agendasSugeridasYaProcesadas;
 
     public EventoDeCausasJudicialesController() {
     }
@@ -49,6 +59,10 @@ public class EventoDeCausasJudicialesController implements Serializable {
 
     public void setSelectedParaEventoJudicialNuevo(EventoDeCausasJudiciales selectedParaEventoJudicialNuevo) {
         this.selectedParaEventoJudicialNuevo = selectedParaEventoJudicialNuevo;
+    }
+
+    public List<SugerenciaAgendaJudicial> getAgendasSugeridas() {
+        return agendasSugeridas;
     }
     
     
@@ -145,8 +159,88 @@ public class EventoDeCausasJudicialesController implements Serializable {
         
         persistParaEventoJudicialNuevo(JsfUtil.PersistAction.CREATE, "Evento Judicial creado exitosamente para el nro de orden:"+ orden);
         if (!JsfUtil.isValidationFailed()) {
+            crearAgendasSugeridasSeleccionadas();
             items = null;    // Invalidate list of items to trigger re-query.
         }
+    }
+
+    public void onTipoFechaChange() {
+        agendasSugeridas = construirSugerenciasPorTipo(selectedParaEventoJudicialNuevo != null ? selectedParaEventoJudicialNuevo.getTipoDeFecha() : null);
+    }
+
+    private List<SugerenciaAgendaJudicial> construirSugerenciasPorTipo(String tipoDeFecha) {
+        List<SugerenciaAgendaJudicial> sugerencias = new ArrayList<>();
+        if (tipoDeFecha == null || !tipoDeFecha.toLowerCase(Locale.ROOT).contains("sentencia")) {
+            return sugerencias;
+        }
+        sugerencias.add(new SugerenciaAgendaJudicial("Avisar a cliente resultado de sentencia y estrategia", "Natali D Agostino", 1));
+        sugerencias.add(new SugerenciaAgendaJudicial("Anotar en honorarios salida de sentencia y próximos pasos", "Daniela Correa", 1));
+        sugerencias.add(new SugerenciaAgendaJudicial("Preparar apelación", "Juan Pablo Cuello", 1));
+        sugerencias.add(new SugerenciaAgendaJudicial("Verificar si ANSES apeló o solicitar sentencia firme", "Natali D Agostino", 5));
+        return sugerencias;
+    }
+
+    private void crearAgendasSugeridasSeleccionadas() {
+        if (agendasSugeridasYaProcesadas || selectedParaEventoJudicialNuevo == null || selectedParaEventoJudicialNuevo.getFecha() == null) {
+            return;
+        }
+        Integer orden = selectedParaEventoJudicialNuevo.getOrden();
+        if (orden == null) {
+            return;
+        }
+        ExpedienteController expedienteController = FacesContext.getCurrentInstance().getApplication().evaluateExpressionGet(FacesContext.getCurrentInstance(), "#{expedienteController}", ExpedienteController.class);
+        if (expedienteController == null || expedienteController.getSelected() == null) {
+            return;
+        }
+        String nombre = expedienteController.getSelected().getNombre();
+        String apellido = expedienteController.getSelected().getApellido();
+
+        for (SugerenciaAgendaJudicial sugerida : agendasSugeridas) {
+            if (!sugerida.isSeleccionada()) {
+                continue;
+            }
+            Date fechaAgenda = sumarDiasHabiles(selectedParaEventoJudicialNuevo.getFecha(), sugerida.getDiasHabilesOffset());
+            if (existeAgendaDuplicada(orden, sugerida.getDescripcion(), fechaAgenda)) {
+                continue;
+            }
+            Agenda agenda = new Agenda();
+            agenda.setOrden(orden);
+            agenda.setNombre(nombre);
+            agenda.setApellido(apellido);
+            agenda.setDescripcion(sugerida.getDescripcion());
+            agenda.setFecha(fechaAgenda);
+            agenda.setResponsable(sugerida.getResponsable());
+            agenda.setRealizado("No");
+            agenda.setPrioridad("No");
+            agendaFacade.create(agenda);
+        }
+        agendasSugeridasYaProcesadas = true;
+    }
+
+    private boolean existeAgendaDuplicada(Integer orden, String descripcion, Date fecha) {
+        List<Agenda> agendasPorOrden = agendaFacade.getItemsByOrder(orden);
+        for (Agenda agenda : agendasPorOrden) {
+            if (agenda.getFecha() != null && agenda.getDescripcion() != null
+                    && Objects.equals(agenda.getDescripcion().trim(), descripcion.trim())
+                    && agenda.getFecha().compareTo(fecha) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Date sumarDiasHabiles(Date base, int diasHabiles) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(base);
+        int agregados = 0;
+        while (agregados < diasHabiles) {
+            calendar.add(Calendar.DAY_OF_MONTH, 1);
+            int diaSemana = calendar.get(Calendar.DAY_OF_WEEK);
+            if (diaSemana != Calendar.SATURDAY && diaSemana != Calendar.SUNDAY) {
+                agregados++;
+            }
+        }
+        return calendar.getTime();
     }
     
     private void persistParaEventoJudicialNuevo(JsfUtil.PersistAction persistAction, String successMessage) {
@@ -186,9 +280,33 @@ public class EventoDeCausasJudicialesController implements Serializable {
     public EventoDeCausasJudiciales prepareCreateEventoJudicial(int orden) {
         selectedParaEventoJudicialNuevo = new EventoDeCausasJudiciales();
         selectedParaEventoJudicialNuevo.setOrden(orden);
+        agendasSugeridas = new ArrayList<>();
+        agendasSugeridasYaProcesadas = false;
         initializeEmbeddableKey();
 
         return selectedParaEventoJudicialNuevo;
+    }
+
+    public static class SugerenciaAgendaJudicial implements Serializable {
+        private String descripcion;
+        private String responsable;
+        private int diasHabilesOffset;
+        private boolean seleccionada;
+
+        public SugerenciaAgendaJudicial(String descripcion, String responsable, int diasHabilesOffset) {
+            this.descripcion = descripcion;
+            this.responsable = responsable;
+            this.diasHabilesOffset = diasHabilesOffset;
+        }
+
+        public String getDescripcion() { return descripcion; }
+        public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
+        public String getResponsable() { return responsable; }
+        public void setResponsable(String responsable) { this.responsable = responsable; }
+        public int getDiasHabilesOffset() { return diasHabilesOffset; }
+        public void setDiasHabilesOffset(int diasHabilesOffset) { this.diasHabilesOffset = diasHabilesOffset; }
+        public boolean isSeleccionada() { return seleccionada; }
+        public void setSeleccionada(boolean seleccionada) { this.seleccionada = seleccionada; }
     }
 
 }

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
@@ -24,6 +24,7 @@
                                         requiredMessage="Debe seleccionar un tipo de fecha"
                  
                                      > 
+                            <p:ajax event="change" listener="#{eventoDeCausasJudicialesController.onTipoFechaChange}" update="agendasSugeridasPanel" />
                             <f:selectItem itemLabel=" -- Seleccione un tipo de fecha --" itemValue="" noSelectionOption="true" />
                             <f:selectItem itemLabel="Reclamo administrativo" itemValue="Reclamo administrativo" />
                             <f:selectItem itemLabel="Resolución denegatoria" itemValue="Resolución denegatoria" />
@@ -52,6 +53,30 @@
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
                         </p:selectOneMenu>
+
+                        <h:panelGroup id="agendasSugeridasPanel" layout="block" style="margin-top:12px; width:100%;">
+                            <p:outputPanel rendered="#{not empty eventoDeCausasJudicialesController.agendasSugeridas}">
+                                <p:outputLabel value="Agendas sugeridas para este tipo de movimiento:" style="font-weight:bold;" />
+                                <p:dataTable value="#{eventoDeCausasJudicialesController.agendasSugeridas}" var="sugerida"
+                                             style="margin-top:8px" styleClass="tabla-tailwind"
+                                             emptyMessage="No hay agendas predeterminadas para este tipo de fecha.">
+                                    <p:column style="width:8%; text-align:center;">
+                                        <p:selectBooleanCheckbox value="#{sugerida.seleccionada}" />
+                                    </p:column>
+                                    <p:column headerText="Descripción" style="width:55%;">
+                                        <h:outputText value="#{sugerida.descripcion}" />
+                                    </p:column>
+                                    <p:column headerText="Día objetivo" style="width:17%;">
+                                        <h:outputText value="#{sugerida.diasHabilesOffset eq 1 ? 'Al día siguiente hábil' : 'A los '.concat(sugerida.diasHabilesOffset).concat(' días hábiles')}" />
+                                    </p:column>
+                                    <p:column headerText="Responsable" style="width:20%;">
+                                        <p:selectOneMenu value="#{sugerida.responsable}">
+                                            <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empl" itemLabel="#{empl.nombre} #{empl.apellido}" itemValue="#{empl.nombre} #{empl.apellido}"/>
+                                        </p:selectOneMenu>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:outputPanel>
+                        </h:panelGroup>
                         
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
@@ -21,6 +21,7 @@
                                          editable="true"
                                          required="true"
                                         requiredMessage="Debe seleccionar un tipo de fecha" >
+                            <p:ajax event="change" listener="#{eventoDeCausasJudicialesController.onTipoFechaChange}" update="agendasSugeridasPanel" />
                             <f:selectItem itemLabel=" -- Seleccione un tipo de fecha --" itemValue="" noSelectionOption="true" />
                             <f:selectItem itemLabel="Reclamo administrativo" itemValue="Reclamo administrativo" />
                             <f:selectItem itemLabel="Resolución denegatoria" itemValue="Resolución denegatoria" />
@@ -49,6 +50,21 @@
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
                         </p:selectOneMenu>
+                        <h:panelGroup id="agendasSugeridasPanel" layout="block" style="margin-top:12px; width:100%;">
+                            <p:outputPanel rendered="#{not empty eventoDeCausasJudicialesController.agendasSugeridas}">
+                                <p:outputLabel value="Agendas sugeridas para este tipo de movimiento:" style="font-weight:bold;" />
+                                <p:dataTable value="#{eventoDeCausasJudicialesController.agendasSugeridas}" var="sugerida" style="margin-top:8px" styleClass="tabla-tailwind">
+                                    <p:column style="width:8%; text-align:center;"><p:selectBooleanCheckbox value="#{sugerida.seleccionada}" /></p:column>
+                                    <p:column headerText="Descripción" style="width:55%;"><h:outputText value="#{sugerida.descripcion}" /></p:column>
+                                    <p:column headerText="Día objetivo" style="width:17%;"><h:outputText value="#{sugerida.diasHabilesOffset eq 1 ? 'Al día siguiente hábil' : 'A los '.concat(sugerida.diasHabilesOffset).concat(' días hábiles')}" /></p:column>
+                                    <p:column headerText="Responsable" style="width:20%;">
+                                        <p:selectOneMenu value="#{sugerida.responsable}">
+                                            <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empl" itemLabel="#{empl.nombre} #{empl.apellido}" itemValue="#{empl.nombre} #{empl.apellido}"/>
+                                        </p:selectOneMenu>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:outputPanel>
+                        </h:panelGroup>
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha,


### PR DESCRIPTION
### Motivation
- Al crear una fecha judicial cuyo tipo de movimiento sea una "sentencia" se deben sugerir agendas predeterminadas para ahorrar pasos al usuario y garantizar responsables por defecto sin romper la UX actual. 

### Description
- Se agregó lógica en `EventoDeCausasJudicialesController` para construir una lista de sugerencias (`SugerenciaAgendaJudicial`) cuando el `tipoDeFecha` contiene "sentencia", mantenerlas en memoria y permitir marcarlas para creación automática cuando se guarde la fecha judicial.  
- Se reutiliza `AgendaFacade` para persistir las agendas y se añadió prevención de duplicados basada en `orden + descripción + fecha` y un flag para evitar doble inserción por doble submit.  
- Se extendieron los formularios JSF (`CreateEventoCausasJudicialesParaExpJudicial.xhtml` y `CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml`) para mostrar, vía `p:ajax` (solo actualiza `agendasSugeridasPanel`), una `p:dataTable` con un `p:selectBooleanCheckbox` por sugerencia y un `p:selectOneMenu` para editar el responsable antes de guardar.  
- No se añadieron nuevas entidades ni cambios en la base de datos, la sugerencia es una clase interna ligera dentro del controller y la persistencia usa las facades existentes. 

### Testing
- Se intentó compilar con `ant -q compile` en el entorno de trabajo y falló por ausencia de `ant` en la imagen (`/bin/bash: line 1: ant: command not found`).
- No se ejecutaron tests automáticos adicionales en el entorno; los cambios fueron compilados conceptualmente y validados por inspección estática de las modificaciones en los archivos `src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java`, `web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml` y `web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94bbfe0088327a440653eb2de7b5c)