### PR TITLE
Arreglar actualización del selector Oficina en Crear reunión

### DIFF
--- a/web/turno/CreateReunion.xhtml
+++ b/web/turno/CreateReunion.xhtml
@@ -26,9 +26,11 @@
                         <p:selectOneMenu id="tipoDeTurnoReunion" value="#{turnoController.selected.tipoDeTurno}" editable="true" effect="fold">
                             <f:selectItem itemLabel="TELEFÓNICO" itemValue="TELEFÓNICO" />
                             <f:selectItem itemLabel="PRESENCIAL" itemValue="PRESENCIAL" />
-                            <p:ajax update="oficinaReunion" />
+                            <p:ajax process="@this" update="oficinaReunionPanel" />
                         </p:selectOneMenu>
+                    </h:panelGrid>
 
+                    <h:panelGrid id="oficinaReunionPanel" columns="2" cellpadding="5">
                         <p:outputLabel value="Oficina:" for="oficinaReunion" style="font-weight: bold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}"/>
                         <p:selectOneMenu id="oficinaReunion" value="#{turnoController.selected.oficina}" editable="true" effect="fold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}">
                             <f:selectItem itemLabel="CERRO" itemValue="CERRO" />


### PR DESCRIPTION
### Motivation
- Evitar que el AJAX intente actualizar el componente `oficinaReunion` cuando aún no está renderizado al cambiar `Tipo de Turno` en el diálogo `Crear reunión`.

### Description
- En `web/turno/CreateReunion.xhtml` se modificó el `<p:ajax>` del `tipoDeTurnoReunion` a `process="@this" update="oficinaReunionPanel"` y se añadió un `h:panelGrid` con `id="oficinaReunionPanel"` que envuelve el `selectOneMenu` de oficina para asegurar una actualización estable cuando el campo se vuelve visible.

### Testing
- Se validó que `web/turno/CreateReunion.xhtml` sea XML bien formado mediante `python3` + `xml.etree.ElementTree.fromstring()` (éxito); `ant -p` y `xmllint --noout` no se ejecutaron porque las herramientas no están instaladas en el entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04eee5033c832798fb1c767295dfb4)