### PR TITLE
Alinear formulario "Crear reunión" con el patrón de "Crear turno"

### DIFF
--- a/web/turno/CreateReunion.xhtml
+++ b/web/turno/CreateReunion.xhtml
@@ -11,46 +11,47 @@
         <p:dialog id="ReunionCreateDlg" widgetVar="ReunionCreateDialog" modal="true" resizable="false" appendTo="@(body)" header="Crear reunión">
             <h:form id="ReunionCreateForm">
                 <h:panelGroup id="displayReunion">
-                    <h:panelGrid columns="2" cellpadding="5">
-                        <p:outputLabel value="Día y hora:" for="horaYDiaReunion" style="font-weight: bold"/>
-                        <p:calendar id="horaYDiaReunion" pattern="dd/MM/yyyy HH:mm" placeholder="dd/MM/yyyy HH:mm" autocomplete="off"
-                                    value="#{turnoController.selected.horaYDia}" showOn="false"/>
+                    <h:panelGrid columns="4">
 
-                        <p:outputLabel value="Asunto:" for="apellidoReunion" style="font-weight: bold"/>
-                        <p:inputText id="apellidoReunion" value="#{turnoController.selected.apellido}" />
+                        <p:outputLabel value="Día y hora:" for="horaYDiaReunion" style="font-weight: bold"/><br></br>
+                        <p:calendar placeholder="dd/MM/yyyy HH:mm" autocomplete="off" id="horaYDiaReunion" pattern="dd/MM/yyyy HH:mm" value="#{turnoController.selected.horaYDia}" showOn="false"/><br></br><br></br>
 
-                        <p:outputLabel value="Detalle:" for="observacionReunion" style="font-weight: bold"/>
-                        <p:inputTextarea id="observacionReunion" cols="33" rows="5" autoResize="false" value="#{turnoController.selected.observacion}"/>
+                        <p:outputLabel value="Asunto:" for="apellidoReunion" style="font-weight: bold"/><br></br>
+                        <p:inputText id="apellidoReunion" value="#{turnoController.selected.apellido}" /><br></br><br></br>
 
-                        <p:outputLabel value="Tipo de Turno:" for="tipoDeTurnoReunion" style="font-weight: bold"/>
-                        <p:selectOneMenu id="tipoDeTurnoReunion" value="#{turnoController.selected.tipoDeTurno}" editable="true" effect="fold">
+                        <p:outputLabel value="Detalle:" for="observacionReunion" style="font-weight: bold"/><br></br>
+                        <p:inputTextarea cols="33" rows="10" autoResize="false" id="observacionReunion" value="#{turnoController.selected.observacion}"/><br></br><br></br>
+
+                        <p:outputLabel value="Asistentes:" for="asistentes" style="font-weight: bold"/><br></br>
+                        <p:selectCheckboxMenu id="asistentes" label="Seleccionar asistentes" filter="true" filterMatchMode="contains"
+                                              panelStyle="width: 350px" scrollHeight="220"
+                                              value="#{turnoController.responsablesSeleccionadosReunion}">
+                            <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
+                                           itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"/>
+                        </p:selectCheckboxMenu><br></br><br></br>
+
+                        <p:outputLabel value="Tipo de Turno:" for="tipoDeTurnoReunion" style="font-weight: bold" /><br></br>
+                        <p:selectOneMenu id="tipoDeTurnoReunion" value="#{turnoController.selected.tipoDeTurno}" editable="true" effect="fold" >
                             <f:selectItem itemLabel="TELEFÓNICO" itemValue="TELEFÓNICO" />
                             <f:selectItem itemLabel="PRESENCIAL" itemValue="PRESENCIAL" />
-                            <p:ajax process="@this" update="oficinaReunionPanel" />
-                        </p:selectOneMenu>
+                            <p:ajax update="inputPanelOficinaReunion" />
+                        </p:selectOneMenu><br></br><br></br>
+
                     </h:panelGrid>
 
-                    <h:panelGrid id="oficinaReunionPanel" columns="2" cellpadding="5">
-                        <p:outputLabel value="Oficina:" for="oficinaReunion" style="font-weight: bold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}"/>
-                        <p:selectOneMenu id="oficinaReunion" value="#{turnoController.selected.oficina}" editable="true" effect="fold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}">
+                    <h:panelGrid id="inputPanelOficinaReunion" columns="4">
+                        <p:outputLabel value="Oficina:" for="oficinaReunion" style="font-weight: bold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}" /><br></br>
+
+                        <p:selectOneMenu rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}" id="oficinaReunion" value="#{turnoController.selected.oficina}" editable="true" effect="fold" >
                             <f:selectItem itemLabel="CERRO" itemValue="CERRO" />
                             <f:selectItem itemLabel="CENTRO" itemValue="CENTRO" />
-                        </p:selectOneMenu>
+                        </p:selectOneMenu><br></br><br></br>
+
                     </h:panelGrid>
-
-                    <p:outputLabel value="Asistentes:" style="font-weight: bold"/>
-                    <p:selectCheckboxMenu id="asistentes" label="Seleccionar asistentes" filter="true" filterMatchMode="contains"
-                                          panelStyle="width: 350px" scrollHeight="220"
-                                          value="#{turnoController.responsablesSeleccionadosReunion}">
-                        <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
-                                       itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"/>
-                    </p:selectCheckboxMenu>
-
-                    <br/><br/>
 
                     <p:commandButton actionListener="#{turnoController.createReunion}"
                                      class="botonCrear"
-                                     value="Guardar reunión"
+                                     value="#{bundle.Save}"
                                      update="displayReunion,:TurnoListForm:datalist,:growl"
                                      oncomplete="handleSubmit(args,'ReunionCreateDialog');PF('turnosTable').clearFilters()"/>
 


### PR DESCRIPTION
### Motivation
- Unificar la presentación de la pantalla de "Crear reunión" para que sea visualmente consistente con "Crear turno" y así corregir el bug de discrepancia en la interfaz.

### Description
- Cambia la estructura del diálogo `web/turno/CreateReunion.xhtml` de una grilla de 2 columnas a 4 columnas y replica el espaciado usado en `Create.xhtml` con saltos `<br></br>` para mantener consistencia visual.
- Mueve el selector de `Asistentes` dentro de la misma grilla principal y lo deja como `p:selectCheckboxMenu` con filtro para que quede alineado con los demás campos.
- Alinea el panel condicional de oficina renombrando/centralizando el id a `inputPanelOficinaReunion` y ajusta el `p:ajax` para que actualice ese panel, igual que en `Create.xhtml`.
- Establece el texto del botón de guardado a `#{bundle.Save}` para usar el mismo label internacionalizado que el resto del sistema.

### Testing
- Se ejecutó `git diff --check` y no mostró errores de formato o conflictos (succeeded).
- Se validó el XML con `python3` usando `xml.etree.ElementTree.parse('web/turno/CreateReunion.xhtml')` y la parseación fue exitosa (`XML OK`).
- `xmllint --noout web/turno/CreateReunion.xhtml` no pudo ejecutarse porque `xmllint` no está disponible en el entorno (skipped).
- `ant -q compile` no pudo ejecutarse porque `ant` no está disponible en el entorno (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a053279fd388327b8b90d40aa1a8e0f)