### PR TITLE
Ajustar modal de "Crear reunión"

### DIFF
--- a/web/resources/css/jsfcrud.css
+++ b/web/resources/css/jsfcrud.css
@@ -1820,3 +1820,112 @@ display: flex;
   overflow-wrap: anywhere;
   line-height: 1.25rem;
 }
+
+/* =========================
+   Modal Crear reunión
+   ========================= */
+.ui-dialog.reunion-create-dialog {
+    width: 340px !important;
+    border-radius: 2px !important;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.55) !important;
+}
+
+.ui-dialog.reunion-create-dialog .ui-dialog-titlebar {
+    background: #123a6d !important;
+    color: #ffffff !important;
+    padding: 0.55rem 0.75rem !important;
+    text-shadow: none !important;
+}
+
+.ui-dialog.reunion-create-dialog .ui-dialog-title {
+    font-size: 13px !important;
+    font-weight: 700 !important;
+}
+
+.ui-dialog.reunion-create-dialog .ui-dialog-content {
+    padding: 12px 12px 6px 12px !important;
+    overflow: visible !important;
+}
+
+.reunion-create-modal {
+    overflow: visible;
+}
+
+.reunion-create-grid {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0 9px;
+}
+
+.reunion-create-grid td {
+    padding: 0 !important;
+    vertical-align: middle;
+}
+
+.reunion-create-label {
+    width: 105px;
+    padding-right: 6px !important;
+}
+
+.reunion-create-field {
+    width: 205px;
+}
+
+.reunion-label {
+    color: #333333 !important;
+    display: block;
+    font-weight: 700 !important;
+    line-height: 1.1;
+}
+
+.reunion-textarea-label {
+    vertical-align: middle !important;
+}
+
+.reunion-input,
+.reunion-input input,
+.reunion-input textarea,
+.reunion-input.ui-selectcheckboxmenu,
+.reunion-input.ui-selectonemenu {
+    box-sizing: border-box;
+    width: 100% !important;
+}
+
+.reunion-textarea {
+    min-height: 168px !important;
+    resize: none;
+}
+
+.reunion-asistentes-label {
+    background: #ffffff;
+    border: 1px solid #c9c9c9;
+    border-radius: 5px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
+    color: #4a4a4a !important;
+    display: inline-block;
+    font-size: 18px !important;
+    font-weight: 400 !important;
+    margin-left: -30px;
+    padding: 5px 10px;
+    position: relative;
+    text-transform: uppercase;
+    white-space: nowrap;
+    z-index: 2;
+}
+
+.reunion-office-grid {
+    margin-top: -3px;
+}
+
+.reunion-actions {
+    display: block;
+    margin-top: 26px;
+}
+
+.reunion-actions .ui-button {
+    margin-right: 4px;
+}
+
+.reunion-cancel-button {
+    font-weight: 700 !important;
+}

--- a/web/turno/CreateReunion.xhtml
+++ b/web/turno/CreateReunion.xhtml
@@ -8,54 +8,55 @@
 
     <ui:composition>
 
-        <p:dialog id="ReunionCreateDlg" widgetVar="ReunionCreateDialog" modal="true" resizable="false" appendTo="@(body)" header="Crear reunión">
+        <p:dialog id="ReunionCreateDlg" widgetVar="ReunionCreateDialog" modal="true" resizable="false" appendTo="@(body)" header="Crear reunión" styleClass="reunion-create-dialog">
             <h:form id="ReunionCreateForm">
-                <h:panelGroup id="displayReunion">
-                    <h:panelGrid columns="4">
+                <h:panelGroup id="displayReunion" layout="block" styleClass="reunion-create-modal">
+                    <h:panelGrid columns="2" columnClasses="reunion-create-label,reunion-create-field" styleClass="reunion-create-grid">
 
-                        <p:outputLabel value="Día y hora:" for="horaYDiaReunion" style="font-weight: bold"/><br></br>
-                        <p:calendar placeholder="dd/MM/yyyy HH:mm" autocomplete="off" id="horaYDiaReunion" pattern="dd/MM/yyyy HH:mm" value="#{turnoController.selected.horaYDia}" showOn="false"/><br></br><br></br>
+                        <p:outputLabel value="Día y hora:" for="horaYDiaReunion" styleClass="reunion-label" />
+                        <p:calendar placeholder="dd/MM/yyyy HH:mm" autocomplete="off" id="horaYDiaReunion" pattern="dd/MM/yyyy HH:mm" value="#{turnoController.selected.horaYDia}" showOn="false" styleClass="reunion-input" />
 
-                        <p:outputLabel value="Asunto:" for="apellidoReunion" style="font-weight: bold"/><br></br>
-                        <p:inputText id="apellidoReunion" value="#{turnoController.selected.apellido}" /><br></br><br></br>
+                        <p:outputLabel value="Asunto:" for="asuntoReunion" styleClass="reunion-label" />
+                        <p:inputText id="asuntoReunion" value="#{turnoController.selected.apellido}" styleClass="reunion-input" />
 
-                        <p:outputLabel value="Detalle:" for="observacionReunion" style="font-weight: bold"/><br></br>
-                        <p:inputTextarea cols="33" rows="10" autoResize="false" id="observacionReunion" value="#{turnoController.selected.observacion}"/><br></br><br></br>
+                        <p:outputLabel value="Detalle:" for="observacionReunion" styleClass="reunion-label reunion-textarea-label" />
+                        <p:inputTextarea cols="33" rows="10" autoResize="false" id="observacionReunion" value="#{turnoController.selected.observacion}" styleClass="reunion-input reunion-textarea" />
 
-                        <p:outputLabel value="Asistentes:" for="asistentes" style="font-weight: bold"/><br></br>
+                        <p:outputLabel value="ASISTENTES" for="asistentes" styleClass="reunion-label reunion-asistentes-label" />
                         <p:selectCheckboxMenu id="asistentes" label="Seleccionar asistentes" filter="true" filterMatchMode="contains"
-                                              panelStyle="width: 350px" scrollHeight="220"
+                                              panelStyle="width: 350px" scrollHeight="220" styleClass="reunion-input reunion-asistentes"
                                               value="#{turnoController.responsablesSeleccionadosReunion}">
                             <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
-                                           itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"/>
-                        </p:selectCheckboxMenu><br></br><br></br>
+                                           itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                        </p:selectCheckboxMenu>
 
-                        <p:outputLabel value="Tipo de Turno:" for="tipoDeTurnoReunion" style="font-weight: bold" /><br></br>
-                        <p:selectOneMenu id="tipoDeTurnoReunion" value="#{turnoController.selected.tipoDeTurno}" editable="true" effect="fold" >
+                        <p:outputLabel value="Tipo de Turno:" for="tipoDeTurnoReunion" styleClass="reunion-label" />
+                        <p:selectOneMenu id="tipoDeTurnoReunion" value="#{turnoController.selected.tipoDeTurno}" editable="true" effect="fold" styleClass="reunion-input">
                             <f:selectItem itemLabel="TELEFÓNICO" itemValue="TELEFÓNICO" />
                             <f:selectItem itemLabel="PRESENCIAL" itemValue="PRESENCIAL" />
                             <p:ajax update="inputPanelOficinaReunion" />
-                        </p:selectOneMenu><br></br><br></br>
+                        </p:selectOneMenu>
 
                     </h:panelGrid>
 
-                    <h:panelGrid id="inputPanelOficinaReunion" columns="4">
-                        <p:outputLabel value="Oficina:" for="oficinaReunion" style="font-weight: bold" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}" /><br></br>
+                    <h:panelGrid id="inputPanelOficinaReunion" columns="2" columnClasses="reunion-create-label,reunion-create-field" styleClass="reunion-create-grid reunion-office-grid">
+                        <p:outputLabel value="Oficina:" for="oficinaReunion" styleClass="reunion-label" rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}" />
 
-                        <p:selectOneMenu rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}" id="oficinaReunion" value="#{turnoController.selected.oficina}" editable="true" effect="fold" >
+                        <p:selectOneMenu rendered="#{turnoController.selected.tipoDeTurno == 'PRESENCIAL'}" id="oficinaReunion" value="#{turnoController.selected.oficina}" editable="true" effect="fold" styleClass="reunion-input">
                             <f:selectItem itemLabel="CERRO" itemValue="CERRO" />
                             <f:selectItem itemLabel="CENTRO" itemValue="CENTRO" />
-                        </p:selectOneMenu><br></br><br></br>
-
+                        </p:selectOneMenu>
                     </h:panelGrid>
 
-                    <p:commandButton actionListener="#{turnoController.createReunion}"
-                                     class="botonCrear"
-                                     value="#{bundle.Save}"
-                                     update="displayReunion,:TurnoListForm:datalist,:growl"
-                                     oncomplete="handleSubmit(args,'ReunionCreateDialog');PF('turnosTable').clearFilters()"/>
+                    <h:panelGroup layout="block" styleClass="reunion-actions">
+                        <p:commandButton actionListener="#{turnoController.createReunion}"
+                                         class="botonCrear"
+                                         value="#{bundle.Save}"
+                                         update="displayReunion,:TurnoListForm:datalist,:growl"
+                                         oncomplete="handleSubmit(args,'ReunionCreateDialog');PF('turnosTable').clearFilters()" />
 
-                    <p:commandButton value="#{bundle.Cancel}" onclick="ReunionCreateDialog.hide()"/>
+                        <p:commandButton value="#{bundle.Cancel}" onclick="ReunionCreateDialog.hide()" styleClass="reunion-cancel-button" />
+                    </h:panelGroup>
                 </h:panelGroup>
             </h:form>
         </p:dialog>


### PR DESCRIPTION
### Motivation
- Actualizar la ventana modal de `Crear reunión` para que coincida con la referencia visual proporcionada, con layout más compacto y etiqueta destacada de asistentes.

### Description
- Reemplacé la estructura del formulario en `web/turno/CreateReunion.xhtml` para usar una grilla de 2 columnas (`h:panelGrid`) y clases CSS específicas, eliminando saltos manuales y ordenando campos (día/hora, asunto, detalle, asistentes, tipo/oficina, acciones). 
- Añadí la clase de diálogo `reunion-create-dialog` y nuevas clases de control (`reunion-create-grid`, `reunion-label`, `reunion-input`, etc.) para mantener el binding existente con `turnoController` sin cambiar la lógica. 
- Agregué estilos a `web/resources/css/jsfcrud.css` para dar ancho fijo, encabezado azul, sombreado, espaciado, textarea más alto y una etiqueta tipo cartel para `ASISTENTES` que reproduce la imagen de referencia. 
- No se modificó la lógica del backend; `turnoController.responsablesSeleccionadosReunion` y la acción `createReunion` siguen funcionando igual.

### Testing
- Se validó que `web/turno/CreateReunion.xhtml` sea XML válido con `python3 - <<'PY' ... ET.parse('web/turno/CreateReunion.xhtml')` y la comprobación final fue satisfactoria. 
- Se ejecutó `git diff --check` y no arrojó conflictos ni advertencias sintácticas sobre los diffs.
- `xmllint --noout web/turno/CreateReunion.xhtml` no pudo ejecutarse porque `xmllint` no está disponible en el entorno, por lo que esa verificación se omitió. 
- `ant -q clean dist` no pudo ejecutarse porque `ant` no está instalado en el entorno, por lo que la construcción/empaquetado no se probó aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a59709788327a8417b08d6528a28)