### PR TITLE
Agregar selector de agendas predeterminadas para "Sentencia 1ra instancia"

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
@@ -1,6 +1,9 @@
 package com.estudioAlvarezVersion2.jsf;
 
 import com.estudioAlvarezVersion2.jpa.EventoDeCausasJudiciales;
+import com.estudioAlvarezVersion2.jpa.Agenda;
+import com.estudioAlvarezVersion2.jpa.Expediente;
+import com.estudioAlvarezVersion2.jpacontroller.AgendaFacade;
 import com.estudioAlvarezVersion2.jpacontroller.EventoDeCausasJudicialesFacade;
 import com.estudioAlvarezVersion2.jsf.util.JsfUtil;
 import javax.ejb.EJB;
@@ -8,6 +11,7 @@ import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
@@ -17,6 +21,7 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.FacesConverter;
+import java.util.Calendar;
 
 /**
  *
@@ -28,9 +33,12 @@ public class EventoDeCausasJudicialesController implements Serializable {
 
     @EJB
     private EventoDeCausasJudicialesFacade ejbFacade;
+    @EJB
+    private AgendaFacade agendaFacade;
     private List<EventoDeCausasJudiciales> items = null;
     private EventoDeCausasJudiciales selected;
     private EventoDeCausasJudiciales selectedParaEventoJudicialNuevo;
+    private List<AgendaPredeterminadaSentencia> agendasPredeterminadasSentencia = new ArrayList<>();
 
     public EventoDeCausasJudicialesController() {
     }
@@ -144,6 +152,7 @@ public class EventoDeCausasJudicialesController implements Serializable {
         selectedParaEventoJudicialNuevo.setOrden(orden);
         
         persistParaEventoJudicialNuevo(JsfUtil.PersistAction.CREATE, "Evento Judicial creado exitosamente para el nro de orden:"+ orden);
+        crearAgendasPredeterminadasSiCorresponde(fecha, tipoDeFecha, orden);
         if (!JsfUtil.isValidationFailed()) {
             items = null;    // Invalidate list of items to trigger re-query.
         }
@@ -186,9 +195,115 @@ public class EventoDeCausasJudicialesController implements Serializable {
     public EventoDeCausasJudiciales prepareCreateEventoJudicial(int orden) {
         selectedParaEventoJudicialNuevo = new EventoDeCausasJudiciales();
         selectedParaEventoJudicialNuevo.setOrden(orden);
+        agendasPredeterminadasSentencia = new ArrayList<>();
         initializeEmbeddableKey();
 
         return selectedParaEventoJudicialNuevo;
+    }
+    
+    public void onTipoDeFechaChange() {
+        if (selectedParaEventoJudicialNuevo == null) {
+            return;
+        }
+        if ("Sentencia 1ra instancia".equals(selectedParaEventoJudicialNuevo.getTipoDeFecha())) {
+            inicializarAgendasPredeterminadasSentencia();
+        } else {
+            agendasPredeterminadasSentencia = new ArrayList<>();
+        }
+    }
+    
+    private void inicializarAgendasPredeterminadasSentencia() {
+        agendasPredeterminadasSentencia = new ArrayList<>();
+        String responsablePredeterminado = obtenerResponsablePredeterminadoExpediente();
+        agendasPredeterminadasSentencia.add(new AgendaPredeterminadaSentencia("Avisar a cliente que salió sent. favorable y debemos esperar si ANSES apela + explicar pasos a seguir.", 1, false, responsablePredeterminado));
+        agendasPredeterminadasSentencia.add(new AgendaPredeterminadaSentencia("Avisar a cliente que salió sentencia primera instancia pero debemos apelar.", 1, false, responsablePredeterminado));
+        agendasPredeterminadasSentencia.add(new AgendaPredeterminadaSentencia("Anotar en honorarios que salió sentencia y régimen de costas.", 1, false, responsablePredeterminado));
+        agendasPredeterminadasSentencia.add(new AgendaPredeterminadaSentencia("Hacer apelación.", 1, false, responsablePredeterminado));
+        agendasPredeterminadasSentencia.add(new AgendaPredeterminadaSentencia("Verificar si ANSES apeló; si no, solicitar sentencia firme.", 5, true, responsablePredeterminado));
+    }
+    
+    private String obtenerResponsablePredeterminadoExpediente() {
+        ExpedienteController expedienteController = (ExpedienteController) FacesContext.getCurrentInstance().getApplication()
+                .getELResolver().getValue(FacesContext.getCurrentInstance().getELContext(), null, "expedienteController");
+        if (expedienteController != null && expedienteController.getSelected() != null) {
+            return expedienteController.getSelected().getResponsable();
+        }
+        if (expedienteController != null && expedienteController.getSelectedParaVerExp() != null) {
+            return expedienteController.getSelectedParaVerExp().getResponsable();
+        }
+        return "";
+    }
+    
+    private void crearAgendasPredeterminadasSiCorresponde(Date fechaEvento, String tipoDeFecha, int orden) {
+        if (!"Sentencia 1ra instancia".equals(tipoDeFecha) || fechaEvento == null || agendasPredeterminadasSentencia == null) {
+            return;
+        }
+        ExpedienteController expedienteController = (ExpedienteController) FacesContext.getCurrentInstance().getApplication()
+                .getELResolver().getValue(FacesContext.getCurrentInstance().getELContext(), null, "expedienteController");
+        Expediente expediente = expedienteController != null ? expedienteController.getExpedienteByOrden(orden) : null;
+        if (expediente == null) {
+            return;
+        }
+        for (AgendaPredeterminadaSentencia agendaConfig : agendasPredeterminadasSentencia) {
+            if (!agendaConfig.isSeleccionada()) continue;
+            Agenda agenda = new Agenda();
+            agenda.setFecha(agendaConfig.isDiasHabiles() ? sumarDiasHabiles(fechaEvento, agendaConfig.getDiasOffset()) : sumarDiasCorridos(fechaEvento, agendaConfig.getDiasOffset()));
+            agenda.setDescripcion(agendaConfig.getDescripcion());
+            agenda.setNombre(expediente.getNombre());
+            agenda.setApellido(expediente.getApellido());
+            agenda.setOrden(orden);
+            agenda.setResponsable(agendaConfig.getResponsable());
+            agenda.setRealizado("No");
+            agenda.setPrioridad("No");
+            agendaFacade.create(agenda);
+        }
+    }
+    
+    private Date sumarDiasCorridos(Date fecha, int dias) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(fecha);
+        calendar.add(Calendar.DATE, dias);
+        return calendar.getTime();
+    }
+    
+    private Date sumarDiasHabiles(Date fecha, int diasHabiles) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(fecha);
+        int agregados = 0;
+        while (agregados < diasHabiles) {
+            calendar.add(Calendar.DATE, 1);
+            int day = calendar.get(Calendar.DAY_OF_WEEK);
+            if (day != Calendar.SATURDAY && day != Calendar.SUNDAY) {
+                agregados++;
+            }
+        }
+        return calendar.getTime();
+    }
+    
+    public List<AgendaPredeterminadaSentencia> getAgendasPredeterminadasSentencia() {
+        return agendasPredeterminadasSentencia;
+    }
+    
+    public static class AgendaPredeterminadaSentencia implements Serializable {
+        private String descripcion;
+        private int diasOffset;
+        private boolean diasHabiles;
+        private boolean seleccionada;
+        private String responsable;
+        public AgendaPredeterminadaSentencia(String descripcion, int diasOffset, boolean diasHabiles, String responsable) {
+            this.descripcion = descripcion;
+            this.diasOffset = diasOffset;
+            this.diasHabiles = diasHabiles;
+            this.responsable = responsable;
+        }
+        public String getDescripcion() { return descripcion; }
+        public int getDiasOffset() { return diasOffset; }
+        public boolean isDiasHabiles() { return diasHabiles; }
+        public boolean isSeleccionada() { return seleccionada; }
+        public void setSeleccionada(boolean seleccionada) { this.seleccionada = seleccionada; }
+        public String getResponsable() { return responsable; }
+        public void setResponsable(String responsable) { this.responsable = responsable; }
+        public String getEtiquetaPlazo() { return diasHabiles ? "A los " + diasOffset + " días hábiles" : "Al día siguiente"; }
     }
 
 }

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
@@ -24,6 +24,7 @@
                                         requiredMessage="Debe seleccionar un tipo de fecha"
                  
                                      > 
+                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="panelAgendasSentencia"/>
                             <f:selectItem itemLabel=" -- Seleccione un tipo de fecha --" itemValue="" noSelectionOption="true" />
                             <f:selectItem itemLabel="Reclamo administrativo" itemValue="Reclamo administrativo" />
                             <f:selectItem itemLabel="Resolución denegatoria" itemValue="Resolución denegatoria" />
@@ -52,6 +53,28 @@
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
                         </p:selectOneMenu>
+                        
+                        <h:panelGroup id="panelAgendasSentencia" layout="block"
+                                      rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha eq 'Sentencia 1ra instancia'}"
+                                      style="margin-top: 14px">
+                            <p:outputLabel value="Agendas predeterminadas:" style="font-weight:bold; margin-bottom:8px; display:block;"/>
+                            <p:dataTable value="#{eventoDeCausasJudicialesController.agendasPredeterminadasSentencia}" var="agendaPred" style="width:100%">
+                                <p:column style="width:5%; text-align:center">
+                                    <p:selectBooleanCheckbox value="#{agendaPred.seleccionada}" />
+                                </p:column>
+                                <p:column headerText="Plazo" style="width:18%">
+                                    <h:outputText value="#{agendaPred.etiquetaPlazo}"/>
+                                </p:column>
+                                <p:column headerText="Descripción">
+                                    <h:outputText value="#{agendaPred.descripcion}"/>
+                                </p:column>
+                                <p:column headerText="Responsable" style="width:25%">
+                                    <p:selectOneMenu value="#{agendaPred.responsable}">
+                                        <f:selectItems value="#{expedienteController.empleadosSelectOne}" />
+                                    </p:selectOneMenu>
+                                </p:column>
+                            </p:dataTable>
+                        </h:panelGroup>
                         
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
@@ -21,6 +21,7 @@
                                          editable="true"
                                          required="true"
                                         requiredMessage="Debe seleccionar un tipo de fecha" >
+                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="panelAgendasSentencia"/>
                             <f:selectItem itemLabel=" -- Seleccione un tipo de fecha --" itemValue="" noSelectionOption="true" />
                             <f:selectItem itemLabel="Reclamo administrativo" itemValue="Reclamo administrativo" />
                             <f:selectItem itemLabel="Resolución denegatoria" itemValue="Resolución denegatoria" />
@@ -49,6 +50,28 @@
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
                         </p:selectOneMenu>
+                        
+                        <h:panelGroup id="panelAgendasSentencia" layout="block"
+                                      rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha eq 'Sentencia 1ra instancia'}"
+                                      style="margin-top: 14px">
+                            <p:outputLabel value="Agendas predeterminadas:" style="font-weight:bold; margin-bottom:8px; display:block;"/>
+                            <p:dataTable value="#{eventoDeCausasJudicialesController.agendasPredeterminadasSentencia}" var="agendaPred" style="width:100%">
+                                <p:column style="width:5%; text-align:center">
+                                    <p:selectBooleanCheckbox value="#{agendaPred.seleccionada}" />
+                                </p:column>
+                                <p:column headerText="Plazo" style="width:18%">
+                                    <h:outputText value="#{agendaPred.etiquetaPlazo}"/>
+                                </p:column>
+                                <p:column headerText="Descripción">
+                                    <h:outputText value="#{agendaPred.descripcion}"/>
+                                </p:column>
+                                <p:column headerText="Responsable" style="width:25%">
+                                    <p:selectOneMenu value="#{agendaPred.responsable}">
+                                        <f:selectItems value="#{expedienteController.empleadosSelectOne}" />
+                                    </p:selectOneMenu>
+                                </p:column>
+                            </p:dataTable>
+                        </h:panelGroup>
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha,


### PR DESCRIPTION
### Motivation
- Facilitar la creación de agendas comunes cuando se carga una fecha judicial de tipo `Sentencia 1ra instancia` para evitar agregar agendas manuales una por una.
- Permitir que el responsable de cada agenda predeterminada se inicialice con el responsable del expediente pero que sea editable por el usuario.

### Description
- Se añadió un bloque dinámico en los diálogos de creación de fecha judicial (`CreateEventoCausasJudicialesParaExpJudicial.xhtml` y `CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml`) que se muestra cuando se selecciona `Sentencia 1ra instancia` y permite seleccionar con checkbox las agendas predeterminadas a crear, ver su plazo, descripción y elegir un responsable por fila.
- En `EventoDeCausasJudicialesController` se agregó la estructura `AgendaPredeterminadaSentencia`, la inicialización de las agendas sugeridas, la acción `onTipoDeFechaChange()` y la lógica `crearAgendasPredeterminadasSiCorresponde(...)` que crea las agendas seleccionadas usando datos del `Expediente` y guardándolas vía `AgendaFacade`.
- El cálculo de fechas soporta días corridos y días hábiles (se saltean sábados y domingos para los plazos configurados), y las agendas creadas incluyen `nombre`, `apellido`, `orden`, `responsable`, `realizado='No'` y `prioridad='No'`.
- Archivos modificados: `src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java`, `web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml`, `web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml`.

### Testing
- Se verificó el estado del repo con `git status --short` y se realizó el commit con `git commit -m "Agregar agendas predeterminadas al crear Sentencia 1ra instancia"`, ambos comandos retornaron éxito.
- Se generó el mensaje del PR con la herramienta interna `make_pr` con los archivos y descripción actualizados, y la operación completó correctamente.
- No se agregaron ni ejecutaron pruebas automatizadas de unidad o integración en este cambio; no se ejecutó un build automatizado en este rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cffd30ebc83278048781b2a28c755)