### PR TITLE
Agregar bloque dinámico de agendas para Sentencia 1ra instancia

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
@@ -1,12 +1,18 @@
 package com.estudioAlvarezVersion2.jsf;
 
+import com.estudioAlvarezVersion2.jpa.Agenda;
 import com.estudioAlvarezVersion2.jpa.EventoDeCausasJudiciales;
+import com.estudioAlvarezVersion2.jpacontroller.AgendaFacade;
 import com.estudioAlvarezVersion2.jpacontroller.EventoDeCausasJudicialesFacade;
 import com.estudioAlvarezVersion2.jsf.util.JsfUtil;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
 import java.io.Serializable;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -28,11 +34,34 @@ public class EventoDeCausasJudicialesController implements Serializable {
 
     @EJB
     private EventoDeCausasJudicialesFacade ejbFacade;
+    @EJB
+    private AgendaFacade agendaFacade;
     private List<EventoDeCausasJudiciales> items = null;
     private EventoDeCausasJudiciales selected;
     private EventoDeCausasJudiciales selectedParaEventoJudicialNuevo;
+    private boolean mostrarAgendasSentenciaPrimeraInstancia;
+    private List<AgendaSentenciaPrimeraInstancia> agendasSentenciaPrimeraInstancia;
+
+    private static final String SENTENCIA_1RA_INSTANCIA = "Sentencia 1ra instancia";
 
     public EventoDeCausasJudicialesController() {
+        inicializarAgendasSentenciaPrimeraInstancia();
+    }
+
+    public static class AgendaSentenciaPrimeraInstancia implements Serializable {
+        private boolean seleccionada;
+        private Date fecha;
+        private String responsable;
+        private String descripcion;
+
+        public boolean isSeleccionada() { return seleccionada; }
+        public void setSeleccionada(boolean seleccionada) { this.seleccionada = seleccionada; }
+        public Date getFecha() { return fecha; }
+        public void setFecha(Date fecha) { this.fecha = fecha; }
+        public String getResponsable() { return responsable; }
+        public void setResponsable(String responsable) { this.responsable = responsable; }
+        public String getDescripcion() { return descripcion; }
+        public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
     }
 
     public EventoDeCausasJudiciales getSelected() {
@@ -144,6 +173,7 @@ public class EventoDeCausasJudicialesController implements Serializable {
         selectedParaEventoJudicialNuevo.setOrden(orden);
         
         persistParaEventoJudicialNuevo(JsfUtil.PersistAction.CREATE, "Evento Judicial creado exitosamente para el nro de orden:"+ orden);
+        crearAgendasSentenciaPrimeraInstanciaSiCorresponde();
         if (!JsfUtil.isValidationFailed()) {
             items = null;    // Invalidate list of items to trigger re-query.
         }
@@ -186,9 +216,77 @@ public class EventoDeCausasJudicialesController implements Serializable {
     public EventoDeCausasJudiciales prepareCreateEventoJudicial(int orden) {
         selectedParaEventoJudicialNuevo = new EventoDeCausasJudiciales();
         selectedParaEventoJudicialNuevo.setOrden(orden);
+        selectedParaEventoJudicialNuevo.setTipoDeFecha(null);
+        mostrarAgendasSentenciaPrimeraInstancia = false;
+        inicializarAgendasSentenciaPrimeraInstancia();
         initializeEmbeddableKey();
 
         return selectedParaEventoJudicialNuevo;
+    }
+
+    public boolean isMostrarAgendasSentenciaPrimeraInstancia() {
+        return mostrarAgendasSentenciaPrimeraInstancia;
+    }
+
+    public List<AgendaSentenciaPrimeraInstancia> getAgendasSentenciaPrimeraInstancia() {
+        return agendasSentenciaPrimeraInstancia;
+    }
+
+    public void onTipoDeFechaChange() {
+        String tipo = selectedParaEventoJudicialNuevo != null ? selectedParaEventoJudicialNuevo.getTipoDeFecha() : null;
+        mostrarAgendasSentenciaPrimeraInstancia = SENTENCIA_1RA_INSTANCIA.equals(tipo);
+    }
+
+    private void inicializarAgendasSentenciaPrimeraInstancia() {
+        agendasSentenciaPrimeraInstancia = new ArrayList<>();
+        Date siguienteDia = convertLocalDateToDate(sumarDiasHabiles(LocalDate.now(), 1));
+        agendasSentenciaPrimeraInstancia.add(crearAgendaTemplate("Avisar a cliente que salió sentencia de primera instancia favorable pero debemos esperar si ANSES apela + explicar pasos a seguir.", siguienteDia));
+        agendasSentenciaPrimeraInstancia.add(crearAgendaTemplate("Avisar a cliente que salió sentencia de primera instancia pero debemos apelar.", siguienteDia));
+        agendasSentenciaPrimeraInstancia.add(crearAgendaTemplate("Anotar en honorarios que salió sentencia y regulen costas.", siguienteDia));
+        agendasSentenciaPrimeraInstancia.add(crearAgendaTemplate("Hacer apelación.", siguienteDia));
+        agendasSentenciaPrimeraInstancia.add(crearAgendaTemplate("Verificar si ANSES apeló sino solicitar sentencia firme.", convertLocalDateToDate(sumarDiasHabiles(LocalDate.now(), 5))));
+    }
+
+    private AgendaSentenciaPrimeraInstancia crearAgendaTemplate(String descripcion, Date fecha) {
+        AgendaSentenciaPrimeraInstancia agenda = new AgendaSentenciaPrimeraInstancia();
+        agenda.setDescripcion(descripcion);
+        agenda.setFecha(fecha);
+        return agenda;
+    }
+
+    private LocalDate sumarDiasHabiles(LocalDate fechaBase, int diasHabiles) {
+        LocalDate fecha = fechaBase;
+        int agregados = 0;
+        while (agregados < diasHabiles) {
+            fecha = fecha.plusDays(1);
+            if (fecha.getDayOfWeek() != DayOfWeek.SATURDAY && fecha.getDayOfWeek() != DayOfWeek.SUNDAY) {
+                agregados++;
+            }
+        }
+        return fecha;
+    }
+
+    private Date convertLocalDateToDate(LocalDate localDate) {
+        return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    }
+
+    private void crearAgendasSentenciaPrimeraInstanciaSiCorresponde() {
+        if (!mostrarAgendasSentenciaPrimeraInstancia || selectedParaEventoJudicialNuevo == null) {
+            return;
+        }
+        for (AgendaSentenciaPrimeraInstancia agendaConfig : agendasSentenciaPrimeraInstancia) {
+            if (!agendaConfig.isSeleccionada() || agendaConfig.getResponsable() == null || agendaConfig.getResponsable().trim().isEmpty()) {
+                continue;
+            }
+            Agenda agenda = new Agenda();
+            agenda.setFecha(agendaConfig.getFecha());
+            agenda.setResponsable(agendaConfig.getResponsable());
+            agenda.setDescripcion(agendaConfig.getDescripcion());
+            agenda.setOrden(selectedParaEventoJudicialNuevo.getOrden());
+            agenda.setRealizado("No");
+            agenda.setPrioridad("No");
+            agendaFacade.edit(agenda);
+        }
     }
 
 }

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
@@ -51,7 +51,24 @@
                             <f:selectItem itemLabel="Cuarto embargo" itemValue="Cuarto embargo" />
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
+                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
                         </p:selectOneMenu>
+                        
+                        <p:panel id="agendasSentenciaPanel" header="Agendas para Sentencia de 1ra instancia" toggleable="true" collapsed="false"
+                                 rendered="#{eventoDeCausasJudicialesController.mostrarAgendasSentenciaPrimeraInstancia}" style="margin-top:10px;">
+                            <ui:repeat value="#{eventoDeCausasJudicialesController.agendasSentenciaPrimeraInstancia}" var="agendaConfig" varStatus="status">
+                                <h:panelGrid columns="4" cellpadding="6" style="width:100%; margin-bottom:8px; border-bottom: 1px solid #e5e5e5; padding-bottom: 8px;">
+                                    <p:selectBooleanCheckbox value="#{agendaConfig.seleccionada}" />
+                                    <p:calendar value="#{agendaConfig.fecha}" pattern="dd/MM/yyyy" navigator="true" disabledWeekends="true" />
+                                    <p:selectOneMenu value="#{agendaConfig.responsable}" filter="true" filterMatchMode="startsWith">
+                                        <f:selectItem itemLabel="-- Responsable --" itemValue="" noSelectionOption="true"/>
+                                        <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
+                                                       itemLabel="#{empleado.getNombreyApellido()}" itemValue="#{empleado.getNombreyApellido()}" />
+                                    </p:selectOneMenu>
+                                    <h:outputText value="#{agendaConfig.descripcion}" />
+                                </h:panelGrid>
+                            </ui:repeat>
+                        </p:panel>
                         
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
@@ -48,7 +48,23 @@
                             <f:selectItem itemLabel="Cuarto embargo" itemValue="Cuarto embargo" />
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
+                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
                         </p:selectOneMenu>
+                        <p:panel id="agendasSentenciaPanel" header="Agendas para Sentencia de 1ra instancia" toggleable="true" collapsed="false"
+                                 rendered="#{eventoDeCausasJudicialesController.mostrarAgendasSentenciaPrimeraInstancia}" style="margin-top:10px;">
+                            <ui:repeat value="#{eventoDeCausasJudicialesController.agendasSentenciaPrimeraInstancia}" var="agendaConfig">
+                                <h:panelGrid columns="4" cellpadding="6" style="width:100%; margin-bottom:8px; border-bottom: 1px solid #e5e5e5; padding-bottom: 8px;">
+                                    <p:selectBooleanCheckbox value="#{agendaConfig.seleccionada}" />
+                                    <p:calendar value="#{agendaConfig.fecha}" pattern="dd/MM/yyyy" navigator="true" disabledWeekends="true" />
+                                    <p:selectOneMenu value="#{agendaConfig.responsable}" filter="true" filterMatchMode="startsWith">
+                                        <f:selectItem itemLabel="-- Responsable --" itemValue="" noSelectionOption="true"/>
+                                        <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
+                                                       itemLabel="#{empleado.getNombreyApellido()}" itemValue="#{empleado.getNombreyApellido()}" />
+                                    </p:selectOneMenu>
+                                    <h:outputText value="#{agendaConfig.descripcion}" />
+                                </h:panelGrid>
+                            </ui:repeat>
+                        </p:panel>
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha,


### PR DESCRIPTION
### Motivation
- Facilitar la creación automática y opcional de hasta 5 agendas cuando se registra un evento de tipo `Sentencia 1ra instancia` para reducir trabajo manual. 
- Mantener la UX existente y la consistencia entre la pantalla de creación estándar y la creación desde agenda.

### Description
- Se agregó UI dinámico en `CreateEventoCausasJudicialesParaExpJudicial.xhtml` y `CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml` que muestra un `p:panel` con 5 secciones solo cuando se selecciona `Sentencia 1ra instancia` y se actualiza mediante `p:ajax` conectado a `onTipoDeFechaChange`.
- Cada sección contiene un `p:selectBooleanCheckbox` para decidir si crear la agenda, un `p:calendar` con fecha por defecto (día hábil siguiente o +5 días hábiles en la quinta sección), un `p:selectOneMenu` para `responsable` y una `descripcion` precargada.
- En backend se amplió `EventoDeCausasJudicialesController` con la clase interna `AgendaSentenciaPrimeraInstancia`, estado `mostrarAgendasSentenciaPrimeraInstancia`, inicialización de las 5 plantillas, cálculo de días hábiles (`sumarDiasHabiles`) y la función `crearAgendasSentenciaPrimeraInstanciaSiCorresponde()` que crea solo las agendas seleccionadas usando `AgendaFacade`.
- Se resetea el estado al abrir un nuevo formulario con `prepareCreateEventoJudicial` para evitar arrastre de datos entre altas y se integra la creación de agendas al final de `createEventoJudicial`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d220a017c8327aaee75335bd73399)