### PR TITLE
Fix modal reset and immediate Sentencia 1ra instancia panel rendering

### DIFF
--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
@@ -19,7 +19,7 @@
 
                         <p:selectOneMenu id="tipo_de_fecha"
                                          value="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha}"
-                                         editable="true"
+                                         editable="false"
                                          required="true"
                                         requiredMessage="Debe seleccionar un tipo de fecha"
                  
@@ -51,7 +51,7 @@
                             <f:selectItem itemLabel="Cuarto embargo" itemValue="Cuarto embargo" />
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
-                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
+                            <p:ajax event="change" listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
                         </p:selectOneMenu>
                         
                         <p:panel id="agendasSentenciaPanel" header="Agendas para Sentencia de 1ra instancia" toggleable="true" collapsed="false"

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
@@ -18,7 +18,7 @@
                         <p:outputLabel value="Tipo de fecha:" for="tipo_de_fecha" style="margin-top: 10px;"/>
                         <p:selectOneMenu id="tipo_de_fecha"
                                          value="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha}"
-                                         editable="true"
+                                         editable="false"
                                          required="true"
                                         requiredMessage="Debe seleccionar un tipo de fecha" >
                             <f:selectItem itemLabel=" -- Seleccione un tipo de fecha --" itemValue="" noSelectionOption="true" />
@@ -48,7 +48,7 @@
                             <f:selectItem itemLabel="Cuarto embargo" itemValue="Cuarto embargo" />
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
-                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
+                            <p:ajax event="change" listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
                         </p:selectOneMenu>
                         <p:panel id="agendasSentenciaPanel" header="Agendas para Sentencia de 1ra instancia" toggleable="true" collapsed="false"
                                  rendered="#{eventoDeCausasJudicialesController.mostrarAgendasSentenciaPrimeraInstancia}" style="margin-top:10px;">

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -582,7 +582,7 @@
                             <div style="text-align: right ; padding-bottom: 20px ;display: grid;">
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
                                                   actionListener="#{eventoDeCausasJudicialesController.prepareCreateEventoJudicial(expedienteController.selected.orden)}"  value="Crear fecha Judicial " 
-                                                  update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm:datalist6" 
+                                                  update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm:datalist6,:EventoJudicialCreateForm:display" 
                                                   oncomplete="PF('EventoJudicialCreateDialog').show()" />
                             </div>
                             <p:dataTable id="datalist6" value="#{expedienteController.verFechasJudicialesPorNroDeOrden(expedienteController.selected.orden)}" var="item"

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -578,7 +578,7 @@
                             <div style="text-align: right ; padding-bottom: 20px ;display: grid;">
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
                                                   actionListener="#{eventoDeCausasJudicialesController.prepareCreateEventoJudicial(expedienteController.selectedParaVerExp.orden)}"  value="Crear fecha Judicial " 
-                                                  update=":EventoJudicialCreatedesdeagendaForm" 
+                                                  update=":EventoJudicialCreatedesdeagendaForm:display" 
                                                   oncomplete="PF('EventoJudicialCreatedesdeagendaDialog').show()" />
                             </div>
                             <p:dataTable id="datalist6" value="#{expedienteController.verFechasJudicialesPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}" var="item"


### PR DESCRIPTION
### Motivation
- El modal "Crear fecha Judicial" mantenía datos previos al reabrirlo y el panel "Agendas para Sentencia de 1ra instancia" no se mostraba de forma instantánea al elegir `Sentencia 1ra instancia` (se esperaba que aparezca al `change` y/o al tab/blur). 

### Description
- Forcé el refresco del contenido del diálogo al abrirlo añadiendo los `update` a los botones que abren los modales para re-renderizar `:EventoJudicialCreateForm:display` y `:EventoJudicialCreatedesdeagendaForm:display` y así evitar que queden estados previos seleccionados.  
- Cambié `p:selectOneMenu` para que no sea editable (`editable="false"`) en los formularios de creación de evento judicial para evitar comportamiento de autocompletado que retrasaba el `ajax` de selección. 
- Modifiqué el `p:ajax` ligado al select para usar explícitamente `event="change"` y llamar a `#{eventoDeCausasJudicialesController.onTipoDeFechaChange}` con `update="agendasSentenciaPanel"` para que el panel se muestre inmediatamente al cambiar la selección. 
- Los cambios se aplicaron en los cuatro archivos relevantes: `web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml`, `web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml`, `web/expediente/EditExpJudicial.xhtml` y `web/expediente/viewEnAgenda/EditExpJudicial.xhtml`.

### Testing
- Se intentó ejecutar `mvn -q -DskipTests compile` pero falló porque no existe un `pom.xml` en el directorio raíz del workspace, por lo que no se pudo realizar una compilación automática en este entorno (falla esperada por la estructura del repositorio).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2da936908327a76330ed854c7b1a)