### PR TITLE
Mejora visual del modal — Sentencia 1ra instancia

### DIFF
--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
@@ -54,24 +54,34 @@
                             <p:ajax update="agendasSentenciaPanel"  />
                         </p:selectOneMenu>
                         
-                        <h:panelGrid id="agendasSentenciaPanel"  style="margin-top:10px;">
+                        <h:panelGroup id="agendasSentenciaPanel" layout="block" style="margin-top: 12px;">
                             <ui:repeat value="#{eventoDeCausasJudicialesController.agendasSentenciaPrimeraInstancia}" var="agendaConfig" varStatus="status">
-                                <h:panelGrid columns="4" cellpadding="6" style="width:100%; margin-bottom:8px; border-bottom: 1px solid #e5e5e5; padding-bottom: 8px;">
-                                
-                                    <p:selectBooleanCheckbox value="#{agendaConfig.seleccionada}" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}" />
-                                    
-                                    <p:calendar value="#{agendaConfig.fecha}" pattern="dd/MM/yyyy" navigator="true" disabledWeekends="true" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}" />
-                                    
-                                    <p:selectOneMenu value="#{agendaConfig.responsable}" filter="true" filterMatchMode="startsWith" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}">
-                                        <f:selectItem itemLabel="-- Responsable --" itemValue="" noSelectionOption="true"/>
-                                        <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
-                                                       itemLabel="#{empleado.getNombreyApellido()}" itemValue="#{empleado.getNombreyApellido()}" />
-                                    </p:selectOneMenu>
-                                    <h:outputText value="#{agendaConfig.descripcion}" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}"/>
-                                
-                                </h:panelGrid>
+                                <h:panelGroup layout="block" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}"
+                                              style="display:flex; align-items:flex-start; gap:10px; width:100%; margin-bottom:8px; border-bottom:1px solid #e5e5e5; padding:8px 4px; box-sizing:border-box;">
+
+                                    <h:panelGroup layout="block" style="padding-top:5px;">
+                                        <p:selectBooleanCheckbox value="#{agendaConfig.seleccionada}" />
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" style="min-width:140px; max-width:160px;">
+                                        <p:calendar value="#{agendaConfig.fecha}" pattern="dd/MM/yyyy" navigator="true" disabledWeekends="true" style="width:100%;" />
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" style="min-width:180px; max-width:220px;">
+                                        <p:selectOneMenu value="#{agendaConfig.responsable}" filter="true" filterMatchMode="startsWith" style="width:100%;">
+                                            <f:selectItem itemLabel="-- Responsable --" itemValue="" noSelectionOption="true"/>
+                                            <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
+                                                           itemLabel="#{empleado.getNombreyApellido()}" itemValue="#{empleado.getNombreyApellido()}" />
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" style="flex:1; min-width:0; padding-top:5px; color:#444; line-height:1.4; word-break:break-word;">
+                                        <h:outputText value="#{agendaConfig.descripcion}"/>
+                                    </h:panelGroup>
+
+                                </h:panelGroup>
                             </ui:repeat>
-                        </h:panelGrid>
+                        </h:panelGroup>
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha,

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
@@ -50,25 +50,35 @@
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
                             <p:ajax update="agendasSentenciaPanel"  />
                         </p:selectOneMenu>
-                        <h:panelGrid id="agendasSentenciaPanel" 
-                                 rendered="#{eventoDeCausasJudicialesController.mostrarAgendasSentenciaPrimeraInstancia}" style="margin-top:10px;">
+                        <h:panelGroup id="agendasSentenciaPanel" layout="block"
+                                 rendered="#{eventoDeCausasJudicialesController.mostrarAgendasSentenciaPrimeraInstancia}" style="margin-top: 12px;">
                             <ui:repeat value="#{eventoDeCausasJudicialesController.agendasSentenciaPrimeraInstancia}" var="agendaConfig">
-                                <h:panelGrid columns="4" cellpadding="6" style="width:100%; margin-bottom:8px; border-bottom: 1px solid #e5e5e5; padding-bottom: 8px;">
-                                
-                                    <p:selectBooleanCheckbox value="#{agendaConfig.seleccionada}" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}" />
-                                    
-                                    <p:calendar value="#{agendaConfig.fecha}" pattern="dd/MM/yyyy" navigator="true" disabledWeekends="true" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}" />
-                                    
-                                    <p:selectOneMenu value="#{agendaConfig.responsable}" filter="true" filterMatchMode="startsWith" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}" >
-                                        <f:selectItem itemLabel="-- Responsable --" itemValue="" noSelectionOption="true"/>
-                                        <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
-                                                       itemLabel="#{empleado.getNombreyApellido()}" itemValue="#{empleado.getNombreyApellido()}" />
-                                    </p:selectOneMenu>
-                                    <h:outputText value="#{agendaConfig.descripcion}" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}" />
-                                
-                                </h:panelGrid>
+                                <h:panelGroup layout="block" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}"
+                                              style="display:flex; align-items:flex-start; gap:10px; width:100%; margin-bottom:8px; border-bottom:1px solid #e5e5e5; padding:8px 4px; box-sizing:border-box;">
+
+                                    <h:panelGroup layout="block" style="padding-top:5px;">
+                                        <p:selectBooleanCheckbox value="#{agendaConfig.seleccionada}" />
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" style="min-width:140px; max-width:160px;">
+                                        <p:calendar value="#{agendaConfig.fecha}" pattern="dd/MM/yyyy" navigator="true" disabledWeekends="true" style="width:100%;" />
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" style="min-width:180px; max-width:220px;">
+                                        <p:selectOneMenu value="#{agendaConfig.responsable}" filter="true" filterMatchMode="startsWith" style="width:100%;">
+                                            <f:selectItem itemLabel="-- Responsable --" itemValue="" noSelectionOption="true"/>
+                                            <f:selectItems value="#{empleadoController.itemsAvailableSelectOne}" var="empleado"
+                                                           itemLabel="#{empleado.getNombreyApellido()}" itemValue="#{empleado.getNombreyApellido()}" />
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup layout="block" style="flex:1; min-width:0; padding-top:5px; color:#444; line-height:1.4; word-break:break-word;">
+                                        <h:outputText value="#{agendaConfig.descripcion}" />
+                                    </h:panelGroup>
+
+                                </h:panelGroup>
                             </ui:repeat>
-                        </h:panelGrid>
+                        </h:panelGroup>
                     
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha,


### PR DESCRIPTION
### Motivation
- El bloque que se muestra al elegir "Sentencia 1ra instancia" en el modal de creación de evento judicial estaba provocando que el modal se viera desalineado y “roto” con desbordes y columnas mal distribuidas.
- Se buscó mantener la estética y estilos del sistema mientras se evita que descripciones largas y controles aniden mal en el layout actual.

### Description
- Reemplacé el uso de `h:panelGrid` por `h:panelGroup` con `display:flex` para el bloque de agendas de "Sentencia 1ra instancia" en ambos flujos de creación (desde expediente y desde agenda). 
- Moví la condición de renderizado a nivel de fila y reorganizé los elementos en cuatro áreas: checkbox, fecha (`p:calendar`), responsable (`p:selectOneMenu`) y descripción, con anchos `min/max` y `style="width:100%"` en inputs para mantener alineación.
- Añadí estilos de espaciado (`gap`, `padding`, `margin`) y reglas de wrapping (`word-break`, `line-height`) para que las descripciones largas no rompan el modal.
- Cambios confinados a la vista; no se tocó la lógica del controlador ni la carga de datos.

### Testing
- Se ejecutó `rg` para localizar los puntos de inserción y confirmar que se aplicaron los cambios en las dos vistas afectadas, y la búsqueda devolvió las rutas esperadas (éxito).
- Se inspeccionaron los ficheros con `sed`/`nl` para revisar el diff y verificar que sólo se modificó el layout del bloque de agendas, sin alterar bindings o acciones de botón (revisión manual automatizada mediante comandos, éxito).
- Se generó y revisó el `git diff` de los archivos modificados para validar el alcance del cambio (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6219d91c83279e548b5c18cc12de)