### PR TITLE
Fix agenda creation for Sentencia 1ra instancia events

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
@@ -271,13 +271,21 @@ public class EventoDeCausasJudicialesController implements Serializable {
     }
 
     private void crearAgendasSentenciaPrimeraInstanciaSiCorresponde() {
-        if (!mostrarAgendasSentenciaPrimeraInstancia || selectedParaEventoJudicialNuevo == null) {
+        if (selectedParaEventoJudicialNuevo == null
+                || !SENTENCIA_1RA_INSTANCIA.equals(selectedParaEventoJudicialNuevo.getTipoDeFecha())) {
             return;
         }
+
+        int agendasCreadas = 0;
         for (AgendaSentenciaPrimeraInstancia agendaConfig : agendasSentenciaPrimeraInstancia) {
-            if (!agendaConfig.isSeleccionada() || agendaConfig.getResponsable() == null || agendaConfig.getResponsable().trim().isEmpty()) {
+            if (!agendaConfig.isSeleccionada()) {
                 continue;
             }
+            if (agendaConfig.getResponsable() == null || agendaConfig.getResponsable().trim().isEmpty()) {
+                JsfUtil.addErrorMessage("Debe seleccionar un responsable para cada agenda marcada.");
+                continue;
+            }
+
             Agenda agenda = new Agenda();
             agenda.setFecha(agendaConfig.getFecha());
             agenda.setResponsable(agendaConfig.getResponsable());
@@ -285,7 +293,12 @@ public class EventoDeCausasJudicialesController implements Serializable {
             agenda.setOrden(selectedParaEventoJudicialNuevo.getOrden());
             agenda.setRealizado("No");
             agenda.setPrioridad("No");
-            agendaFacade.edit(agenda);
+            agendaFacade.create(agenda);
+            agendasCreadas++;
+        }
+
+        if (agendasCreadas > 0) {
+            JsfUtil.addSuccessMessage("Agendas creadas: " + agendasCreadas);
         }
     }
 

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicial.xhtml
@@ -5,7 +5,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
-    
+
     <ui:composition>
 
         <p:dialog id="EventoJudicialCreateDlg" widgetVar="EventoJudicialCreateDialog" modal="true" resizable="false" appendTo="@(body)" header="Crear Evento Judicial Nuevo">
@@ -14,7 +14,7 @@
                     <div class="botonesapilados" >
                         <p:outputLabel value="Fecha:" for="fecha"  />
                         <p:calendar disabledWeekends="true" mode="inline" required="true" requiredMessage="Fecha es requerido." placeholder="dd/MM/yyyy" autocomplete="off" id="fecha"  pattern="dd/MM/yyyy" value="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha}" title="fecha de causa"  />
-                              
+
                         <p:outputLabel value="Tipo de fecha:" for="tipo_de_fecha"  style="margin-top: 10px" />
 
                         <p:selectOneMenu id="tipo_de_fecha"
@@ -22,8 +22,8 @@
                                          editable="false"
                                          required="true"
                                         requiredMessage="Debe seleccionar un tipo de fecha"
-                 
-                                     > 
+
+                                     >
                             <f:selectItem itemLabel=" -- Seleccione un tipo de fecha --" itemValue="" noSelectionOption="true" />
                             <f:selectItem itemLabel="Reclamo administrativo" itemValue="Reclamo administrativo" />
                             <f:selectItem itemLabel="Resolución denegatoria" itemValue="Resolución denegatoria" />
@@ -51,9 +51,9 @@
                             <f:selectItem itemLabel="Cuarto embargo" itemValue="Cuarto embargo" />
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
-                            <p:ajax update="agendasSentenciaPanel"  />
+                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
                         </p:selectOneMenu>
-                        
+
                         <h:panelGroup id="agendasSentenciaPanel" layout="block" style="margin-top: 12px;">
                             <ui:repeat value="#{eventoDeCausasJudicialesController.agendasSentenciaPrimeraInstancia}" var="agendaConfig" varStatus="status">
                                 <h:panelGroup layout="block" rendered="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha == 'Sentencia 1ra instancia'}"
@@ -82,17 +82,17 @@
                                 </h:panelGroup>
                             </ui:repeat>
                         </h:panelGroup>
-                    
+
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha,
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha ,
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.orden)}"
-                                         class="boton-verde-general" value="#{bundle.Save}" 
-                                         oncomplete="handleSubmit(args,'EventoJudicialCreateDialog');" 
+                                         class="boton-verde-general" value="#{bundle.Save}" process="@form"
+                                         oncomplete="handleSubmit(args,'EventoJudicialCreateDialog');"
                                          update="display,:ExpedienteJudicialEditForm,:growl"/>
-                  
+
                     </div>
-                     
+
                 </h:panelGroup>
             </h:form>
         </p:dialog>

--- a/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
+++ b/web/eventoDeCausaJudicial/CreateEventoCausasJudicialesParaExpJudicialDesdeAgenda.xhtml
@@ -5,7 +5,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
-    
+
     <ui:composition>
 
         <p:dialog id="EventoJudicialCreatedesdeagendaDlg" widgetVar="EventoJudicialCreatedesdeagendaDialog" modal="true" resizable="false" appendTo="@(body)" header="Crear Evento Judicial Nuevo">
@@ -14,7 +14,7 @@
                     <div class="botonesapilados" >
                      <p:outputLabel value="Fecha:" for="fecha"  />
                         <p:calendar disabledWeekends="true" mode="inline" required="true" requiredMessage="Fecha es requerido." placeholder="dd/MM/yyyy" autocomplete="off" id="fecha"  pattern="dd/MM/yyyy" value="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha}" title="fecha de causa"  />
-                                 
+
                         <p:outputLabel value="Tipo de fecha:" for="tipo_de_fecha" style="margin-top: 10px;"/>
                         <p:selectOneMenu id="tipo_de_fecha"
                                          value="#{eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha}"
@@ -48,7 +48,7 @@
                             <f:selectItem itemLabel="Cuarto embargo" itemValue="Cuarto embargo" />
                             <f:selectItem itemLabel="Cuarta transferencia" itemValue="Cuarta transferencia" />
                             <f:selectItem itemLabel="OTRA FECHA JUDICIAL" itemValue="OTRA FECHA JUDICIAL" />
-                            <p:ajax update="agendasSentenciaPanel"  />
+                            <p:ajax listener="#{eventoDeCausasJudicialesController.onTipoDeFechaChange}" update="agendasSentenciaPanel" />
                         </p:selectOneMenu>
                         <h:panelGroup id="agendasSentenciaPanel" layout="block"
                                  rendered="#{eventoDeCausasJudicialesController.mostrarAgendasSentenciaPrimeraInstancia}" style="margin-top: 12px;">
@@ -79,16 +79,16 @@
                                 </h:panelGroup>
                             </ui:repeat>
                         </h:panelGroup>
-                    
+
                     <p:commandButton actionListener="#{eventoDeCausasJudicialesController.createEventoJudicial(
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.fecha,
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.tipoDeFecha ,
                                                            eventoDeCausasJudicialesController.selectedParaEventoJudicialNuevo.orden)}"
-                                         class="boton-verde-general" value="#{bundle.Save}" 
-                                         oncomplete="handleSubmit(args,'EventoJudicialCreatedesdeagendaDialog');" 
+                                         class="boton-verde-general" value="#{bundle.Save}" process="@form"
+                                         oncomplete="handleSubmit(args,'EventoJudicialCreatedesdeagendaDialog');"
                                          update=":ExpedienteJudicialViewDesdeAgendaForm:tabViewEditExpJudicialEditForm:datalist6,:growl"/>
-                  
-             
+
+
                 </div>
                 </h:panelGroup>
             </h:form>


### PR DESCRIPTION
### Motivation
- Arreglar la lógica que debía crear múltiples agendas cuando al guardar un evento judicial se seleccionan varias plantillas para "Sentencia 1ra instancia" y actualmente no se estaban creando todas. 

### Description
- Cambiado `crearAgendasSentenciaPrimeraInstanciaSiCorresponde()` para validar el `tipoDeFecha` del `selectedParaEventoJudicialNuevo` (en vez de depender solo del flag visual) y iterar correctamente las plantillas seleccionadas. 
- Se valida que cada plantilla marcada tenga `responsable` y se muestra un mensaje de error si falta; las agendas ahora se persisten con `agendaFacade.create(...)` en lugar de `edit(...)`. 
- Se contabilizan y muestran las agendas creadas con un `JsfUtil.addSuccessMessage(...)`. 
- En los formularios XHTML se conectó el `p:ajax` al método `onTipoDeFechaChange` y se añadió `process="@form"` al botón Guardar para asegurarse de que todos los checkboxes/fields del subform se envíen al backend. 

### Testing
- Ejecutado `git diff --check` para revisar whitespace y problemas de diff y se corrigieron advertencias (resultado final: OK). 
- Parseo XML de los archivos XHTML con `xml.etree.ElementTree.parse(...)` para validar sintaxis y ambos archivos resultaron OK. 
- Intenté compilar con `ant -q compile` pero falló en este entorno porque `ant` no está instalado (`ant: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bef6a303c83278fe33884744f85ba)