### PR TITLE
Add second Carta Poder slot (DB, upload/download, view)

### DIFF
--- a/CREATE_TABLE_DOCUMENTOS_CARTA_PODER_DOS.sql
+++ b/CREATE_TABLE_DOCUMENTOS_CARTA_PODER_DOS.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS documentosCartaPoderDos (
+    nroDeOrden INT NOT NULL,
+    documento LONGBLOB,
+    nombreDelDocumento VARCHAR(255),
+    PRIMARY KEY (nroDeOrden)
+);

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileDownloadBean.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileDownloadBean.java
@@ -53,6 +53,7 @@ public class FileDownloadBean implements Serializable {
     private StreamedContent fileOtraDocumentacionSeis;
 
     private StreamedContent fileCartaPoder;
+    private StreamedContent fileCartaPoderDos;
     private StreamedContent fileHistorialLaboralAnses;
     
     private StreamedContent fileHistorialLaboralOtrasCajas;
@@ -282,6 +283,14 @@ public class FileDownloadBean implements Serializable {
 
     public void setFileCartaPoder(StreamedContent fileCartaPoder) {
         this.fileCartaPoder = fileCartaPoder;
+    }
+
+    public StreamedContent getFileCartaPoderDos() {
+        return fileCartaPoderDos;
+    }
+
+    public void setFileCartaPoderDos(StreamedContent fileCartaPoderDos) {
+        this.fileCartaPoderDos = fileCartaPoderDos;
     }
 
     public StreamedContent getFileExpAdministrativo() {
@@ -1898,6 +1907,10 @@ public class FileDownloadBean implements Serializable {
                                 fileCartaPoder = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
                                 fileAlmacenado = fileCartaPoder;
                                 break;
+                            case "CartaPoderDos":
+                                fileCartaPoderDos = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileCartaPoderDos;
+                                break;
                             case "ExpAdministrativo":
                                 fileExpAdministrativo = new DefaultStreamedContent(stream, IMAGE_JPEG, rs.getString("nombreDelDocumento"));
                                 fileAlmacenado = fileExpAdministrativo;
@@ -2012,6 +2025,10 @@ public class FileDownloadBean implements Serializable {
                             case "CartaPoder":
                                 fileCartaPoder = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
                                 fileAlmacenado = fileCartaPoder;
+                                break;
+                            case "CartaPoderDos":
+                                fileCartaPoderDos = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
+                                fileAlmacenado = fileCartaPoderDos;
                                 break;
                             case "ExpAdministrativo":
                                 fileExpAdministrativo = new DefaultStreamedContent(stream, APPLICATION_PDF, rs.getString("nombreDelDocumento"));
@@ -3167,6 +3184,22 @@ public class FileDownloadBean implements Serializable {
             } else {
 
                 return cantidad;
+            }
+        }
+
+        return cantidad;
+    }
+
+
+    public int cantidadArchivosCartaPoder(int orden) {
+        int cantidad = 0;
+
+        if (orden != 0) {
+            if (!buscarNombreDeArchivo(orden, "CartaPoder").contains("no existe archivo")) {
+                cantidad += 1;
+            }
+            if (!buscarNombreDeArchivo(orden, "CartaPoderDos").contains("no existe archivo")) {
+                cantidad += 1;
             }
         }
 

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileUploadBean.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/util/FileUploadBean.java
@@ -59,6 +59,7 @@ public class FileUploadBean implements Serializable{
         private UploadedFile fileOtraDocumentacionSeis;
         
         private UploadedFile fileCartaPoder;  
+        private UploadedFile fileCartaPoderDos;
         private UploadedFile fileExpAdministrativo;
         private UploadedFile fileExpAdministrativoDos;
         
@@ -371,6 +372,14 @@ public class FileUploadBean implements Serializable{
 
     public void setFileCartaPoder(UploadedFile fileCartaPoder) {
         this.fileCartaPoder = fileCartaPoder;
+    }
+
+    public UploadedFile getFileCartaPoderDos() {
+        return fileCartaPoderDos;
+    }
+
+    public void setFileCartaPoderDos(UploadedFile fileCartaPoderDos) {
+        this.fileCartaPoderDos = fileCartaPoderDos;
     }
 
     public UploadedFile getFileExpAdministrativo() {
@@ -2105,6 +2114,9 @@ public class FileUploadBean implements Serializable{
             case "ConvenioDeHonorarios":
                  fileParaSubir = fileConvenioDeHonorarios;
                  break;     
+            case "CartaPoderDos":
+                 fileParaSubir = fileCartaPoderDos;
+                 break;
             case "ConstanciaDeCbu":
                  fileParaSubir = fileConstanciaDeCbu;
                  break;     

--- a/web/expediente/ViewDocumentos.xhtml
+++ b/web/expediente/ViewDocumentos.xhtml
@@ -1149,8 +1149,8 @@
 <p:tab>
                             <f:facet name="title">
                                 Carta Poder
-                                <span class="circle-badge"  style=" #{fileDownloadBean.cantidadArchivos(expedienteController.selected.orden, 'CartaPoder') == 0 ? 'background: #e87474; ' : 'background: #00c6ae;'}">
-                                    #{fileDownloadBean.cantidadArchivos(expedienteController.selected.orden, 'CartaPoder')}
+                                <span class="circle-badge"  style=" #{fileDownloadBean.cantidadArchivosCartaPoder(expedienteController.selected.orden) == 0 ? 'background: #e87474; ' : 'background: #00c6ae;'}">
+                                    #{fileDownloadBean.cantidadArchivosCartaPoder(expedienteController.selected.orden)}
                                 </span>
                             </f:facet>
 
@@ -1180,6 +1180,24 @@
 
                                             <p:commandButton class="botonsubirbajarpdf" value="Descargar archivo" actionListener="#{fileDownloadBean.downloadDocumentoPorNombre(expedienteController.selected.orden, 'CartaPoder')}" ajax="false">
                                                 <p:fileDownload value="#{fileDownloadBean.fileCartaPoder}" />
+                                            </p:commandButton>
+                                        </div></div>
+
+                                    <div class="cards1"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'CartaPoderDos').toString().contains('no existe archivo') ? 'border: 3px solid #e87474;background: #ffd5d5; ' : 'border:3px solid #00c6ae;background: #d0fff9;'}">
+
+
+                                        <p:outputLabel value="Nombre del archivo Carta Poder 2:"  styleClass="titulopdfjpg"/><br></br>
+                                        <p:outputLabel  value="#{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'CartaPoderDos')}"
+                                                        styleClass="buscararchivo"  style=" #{fileDownloadBean.buscarNombreDeArchivo(expedienteController.selected.orden, 'CartaPoderDos').toString().contains('no existe archivo') ? 'background-color: #e87474; color: #780C28 ;' : 'background-color: #80d3bb; color:#11665c ;border-left: 5px solid #11665c;'}"
+                                                        /><br></br>
+                                        <p:growl life="2500" showDetail="true"/>
+                                        <p:fileUpload  value="#{fileUploadBean.fileCartaPoderDos}" mode="simple"/>
+
+                                        <div style="display: flex; gap: 10px; margin-top: 10px;">
+                                            <p:commandButton icon="fa-upload" value="Subir archivo" class="botonsubirbajarpdf" action="#{fileUploadBean.uploadDocumentoPorNombre(expedienteController.selected.orden, 'CartaPoderDos')}" ajax="false" />
+
+                                            <p:commandButton class="botonsubirbajarpdf" value="Descargar archivo" actionListener="#{fileDownloadBean.downloadDocumentoPorNombre(expedienteController.selected.orden, 'CartaPoderDos')}" ajax="false">
+                                                <p:fileDownload value="#{fileDownloadBean.fileCartaPoderDos}" />
                                             </p:commandButton>
                                         </div></div></div>
 


### PR DESCRIPTION
### Motivation
- Soportar un segundo archivo de "Carta Poder" en la vista de documentos para poder subir/descargar y mostrar el conteo combinado de ambos espacios.
- Mantener coherencia en todas las capas (DB, upload, download y vista) para que el nuevo espacio funcione igual que los existentes.

### Description
- Añadida la sentencia SQL `CREATE_TABLE_DOCUMENTOS_CARTA_PODER_DOS.sql` que crea la tabla `documentosCartaPoderDos` con la misma estructura que los otros espacios de documento.
- Modificada la vista `web/expediente/ViewDocumentos.xhtml` para mostrar el badge acumulado de Carta Poder y agregar un segundo bloque con `p:fileUpload` y botones de descarga para `CartaPoderDos`.
- Actualizada la clase `FileUploadBean.java` para incluir la propiedad `fileCartaPoderDos` con getters/setters y su manejo en `uploadDocumentoPorNombre(...)` para insertar/actualizar en la tabla `documentosCartaPoderDos`.
- Actualizada la clase `FileDownloadBean.java` para incluir la propiedad `fileCartaPoderDos` con getters/setters, soporte en el `switch` de `downloadDocumentoPorNombre(...)` para JPG/PDF desde `documentosCartaPoderDos`, y añadido `cantidadArchivosCartaPoder(int orden)` para contar ambos archivos.

### Testing
- Ejecutado `python3` para parsear `web/expediente/ViewDocumentos.xhtml` usando `xml.etree.ElementTree` y la comprobación XML fue exitosa.
- Ejecutado un chequeo simple de balance de llaves/paréntesis en `FileUploadBean.java` y `FileDownloadBean.java` y los conteos se mantuvieron equilibrados (sin desajustes detectados).
- Ejecutado `git diff --check` para detectar problemas de formato y no se reportaron errores de chequeo.
- Intentado ejecutar `ant -q compile` para una compilación completa pero no se pudo ejecutar en este entorno porque `ant` no está instalado (compilación no realizada aquí).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265fdd775c8327ac70d8761a55e8e9)