### PR TITLE
Set default 'responsable' for Sentencia 1ra instancia agendas to expediente responsable

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/EventoDeCausasJudicialesController.java
@@ -41,6 +41,7 @@ public class EventoDeCausasJudicialesController implements Serializable {
     private EventoDeCausasJudiciales selectedParaEventoJudicialNuevo;
     private boolean mostrarAgendasSentenciaPrimeraInstancia;
     private List<AgendaSentenciaPrimeraInstancia> agendasSentenciaPrimeraInstancia;
+    private String responsableExpedienteParaAgendasSentenciaPrimeraInstancia;
 
     private static final String SENTENCIA_1RA_INSTANCIA = "Sentencia 1ra instancia";
 
@@ -214,9 +215,14 @@ public class EventoDeCausasJudicialesController implements Serializable {
     }
     
     public EventoDeCausasJudiciales prepareCreateEventoJudicial(int orden) {
+        return prepareCreateEventoJudicial(orden, null);
+    }
+
+    public EventoDeCausasJudiciales prepareCreateEventoJudicial(int orden, String responsableExpediente) {
         selectedParaEventoJudicialNuevo = new EventoDeCausasJudiciales();
         selectedParaEventoJudicialNuevo.setOrden(orden);
         selectedParaEventoJudicialNuevo.setTipoDeFecha(null);
+        responsableExpedienteParaAgendasSentenciaPrimeraInstancia = responsableExpediente;
         mostrarAgendasSentenciaPrimeraInstancia = false;
         inicializarAgendasSentenciaPrimeraInstancia();
         initializeEmbeddableKey();
@@ -235,6 +241,9 @@ public class EventoDeCausasJudicialesController implements Serializable {
     public void onTipoDeFechaChange() {
         String tipo = selectedParaEventoJudicialNuevo != null ? selectedParaEventoJudicialNuevo.getTipoDeFecha() : null;
         mostrarAgendasSentenciaPrimeraInstancia = SENTENCIA_1RA_INSTANCIA.equals(tipo);
+        if (mostrarAgendasSentenciaPrimeraInstancia) {
+            asignarResponsablePorDefectoAAgendasSinResponsable();
+        }
     }
 
     private void inicializarAgendasSentenciaPrimeraInstancia() {
@@ -251,7 +260,20 @@ public class EventoDeCausasJudicialesController implements Serializable {
         AgendaSentenciaPrimeraInstancia agenda = new AgendaSentenciaPrimeraInstancia();
         agenda.setDescripcion(descripcion);
         agenda.setFecha(fecha);
+        agenda.setResponsable(responsableExpedienteParaAgendasSentenciaPrimeraInstancia);
         return agenda;
+    }
+
+    private void asignarResponsablePorDefectoAAgendasSinResponsable() {
+        if (responsableExpedienteParaAgendasSentenciaPrimeraInstancia == null
+                || responsableExpedienteParaAgendasSentenciaPrimeraInstancia.trim().isEmpty()) {
+            return;
+        }
+        for (AgendaSentenciaPrimeraInstancia agendaConfig : agendasSentenciaPrimeraInstancia) {
+            if (agendaConfig.getResponsable() == null || agendaConfig.getResponsable().trim().isEmpty()) {
+                agendaConfig.setResponsable(responsableExpedienteParaAgendasSentenciaPrimeraInstancia);
+            }
+        }
     }
 
     private LocalDate sumarDiasHabiles(LocalDate fechaBase, int diasHabiles) {

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -581,7 +581,7 @@
                         <div class="comunicaciones">
                             <div style="text-align: right ; padding-bottom: 20px ;display: grid;">
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
-                                                  actionListener="#{eventoDeCausasJudicialesController.prepareCreateEventoJudicial(expedienteController.selected.orden)}"  value="Crear fecha Judicial " 
+                                                  actionListener="#{eventoDeCausasJudicialesController.prepareCreateEventoJudicial(expedienteController.selected.orden, expedienteController.selected.responsable)}"  value="Crear fecha Judicial "
                                                   update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm:datalist6,:EventoJudicialCreateForm:display" 
                                                   oncomplete="PF('EventoJudicialCreateDialog').show()" />
                             </div>

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -577,7 +577,7 @@
                         <div class="comunicaciones">
                             <div style="text-align: right ; padding-bottom: 20px ;display: grid;">
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
-                                                  actionListener="#{eventoDeCausasJudicialesController.prepareCreateEventoJudicial(expedienteController.selectedParaVerExp.orden)}"  value="Crear fecha Judicial " 
+                                                  actionListener="#{eventoDeCausasJudicialesController.prepareCreateEventoJudicial(expedienteController.selectedParaVerExp.orden, expedienteController.selectedParaVerExp.responsable)}"  value="Crear fecha Judicial "
                                                   update=":EventoJudicialCreatedesdeagendaForm:display" 
                                                   oncomplete="PF('EventoJudicialCreatedesdeagendaDialog').show()" />
                             </div>


### PR DESCRIPTION
### Motivation
- When creating a `Sentencia 1ra instancia` judicial event the generated agenda templates should default their `responsable` to the expediente's `responsable` while still letting the user change it before creating the agendas.

### Description
- Store a `responsableExpedienteParaAgendasSentenciaPrimeraInstancia` in `EventoDeCausasJudicialesController` and add an overloaded `prepareCreateEventoJudicial(int orden, String responsableExpediente)` to receive it.
- Initialize each `AgendaSentenciaPrimeraInstancia` with that default `responsable` and, when the Sentencia panel is shown, fill any empty `responsable` fields with the expediente responsable so the select remains editable.
- Pass the expediente responsable from the two places that open the dialog by changing the action listeners in `web/expediente/EditExpJudicial.xhtml` and `web/expediente/viewEnAgenda/EditExpJudicial.xhtml` to call `prepareCreateEventoJudicial(..., expedienteController.selected*.responsable)`.

### Testing
- Ran `git diff --check` and repository checks which passed without whitespace errors after trimming the affected lines.
- Attempted `ant clean build` in this environment but it failed because `ant` is not installed, so no full build/test run was executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2660d9ffbc8327b1b01eaaa8dedc1b)