### PR TITLE
Agregar campos DDHH y selector Usuario SAC en Expediente y formularios

### DIFF
--- a/ALTER_TABLE_EXPEDIENTE_ADD_DDHH.sql
+++ b/ALTER_TABLE_EXPEDIENTE_ADD_DDHH.sql
@@ -1,0 +1,15 @@
+ALTER TABLE Expediente ADD COLUMN ddhhCausante VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhDni VARCHAR(50);
+ALTER TABLE Expediente ADD COLUMN ddhhUltimoDomicilio VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhEstadoCivil VARCHAR(100);
+ALTER TABLE Expediente ADD COLUMN ddhhHerederos VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhHerederosDetalle TEXT;
+ALTER TABLE Expediente ADD COLUMN ddhhMotivos VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhMotivoInmuebleDetalle VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhMotivoAutomotorDetalle VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhMotivoCobroCreditoDetalle TEXT;
+ALTER TABLE Expediente ADD COLUMN ddhhMotivoOtroDetalle VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhPadreCausante VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhMadreCausante VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN ddhhObservaciones TEXT;
+ALTER TABLE Expediente ADD COLUMN usuarioSac VARCHAR(255);

--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -294,6 +294,52 @@ public class Expediente implements Serializable {
 
     @Column(name = "jpTipo")
     private String jpTipo;
+
+
+    @Column(name = "ddhhCausante")
+    private String ddhhCausante;
+
+    @Column(name = "ddhhDni")
+    private String ddhhDni;
+
+    @Column(name = "ddhhUltimoDomicilio")
+    private String ddhhUltimoDomicilio;
+
+    @Column(name = "ddhhEstadoCivil")
+    private String ddhhEstadoCivil;
+
+    @Column(name = "ddhhHerederos")
+    private String[] ddhhHerederos;
+
+    @Column(name = "ddhhHerederosDetalle")
+    private String ddhhHerederosDetalle;
+
+    @Column(name = "ddhhMotivos")
+    private String[] ddhhMotivos;
+
+    @Column(name = "ddhhMotivoInmuebleDetalle")
+    private String ddhhMotivoInmuebleDetalle;
+
+    @Column(name = "ddhhMotivoAutomotorDetalle")
+    private String ddhhMotivoAutomotorDetalle;
+
+    @Column(name = "ddhhMotivoCobroCreditoDetalle")
+    private String ddhhMotivoCobroCreditoDetalle;
+
+    @Column(name = "ddhhMotivoOtroDetalle")
+    private String ddhhMotivoOtroDetalle;
+
+    @Column(name = "ddhhPadreCausante")
+    private String ddhhPadreCausante;
+
+    @Column(name = "ddhhMadreCausante")
+    private String ddhhMadreCausante;
+
+    @Column(name = "ddhhObservaciones")
+    private String ddhhObservaciones;
+
+    @Column(name = "usuarioSac")
+    private String usuarioSac;
     
     public Expediente() {
     }
@@ -942,6 +988,38 @@ public class Expediente implements Serializable {
     public void setJpTipo(String jpTipo) {
         this.jpTipo = jpTipo;
     }
+
+
+    public String getDdhhCausante() { return ddhhCausante; }
+    public void setDdhhCausante(String ddhhCausante) { this.ddhhCausante = ddhhCausante; }
+    public String getDdhhDni() { return ddhhDni; }
+    public void setDdhhDni(String ddhhDni) { this.ddhhDni = ddhhDni; }
+    public String getDdhhUltimoDomicilio() { return ddhhUltimoDomicilio; }
+    public void setDdhhUltimoDomicilio(String ddhhUltimoDomicilio) { this.ddhhUltimoDomicilio = ddhhUltimoDomicilio; }
+    public String getDdhhEstadoCivil() { return ddhhEstadoCivil; }
+    public void setDdhhEstadoCivil(String ddhhEstadoCivil) { this.ddhhEstadoCivil = ddhhEstadoCivil; }
+    public String[] getDdhhHerederos() { return ddhhHerederos; }
+    public void setDdhhHerederos(String[] ddhhHerederos) { this.ddhhHerederos = ddhhHerederos; }
+    public String getDdhhHerederosDetalle() { return ddhhHerederosDetalle; }
+    public void setDdhhHerederosDetalle(String ddhhHerederosDetalle) { this.ddhhHerederosDetalle = ddhhHerederosDetalle; }
+    public String[] getDdhhMotivos() { return ddhhMotivos; }
+    public void setDdhhMotivos(String[] ddhhMotivos) { this.ddhhMotivos = ddhhMotivos; }
+    public String getDdhhMotivoInmuebleDetalle() { return ddhhMotivoInmuebleDetalle; }
+    public void setDdhhMotivoInmuebleDetalle(String ddhhMotivoInmuebleDetalle) { this.ddhhMotivoInmuebleDetalle = ddhhMotivoInmuebleDetalle; }
+    public String getDdhhMotivoAutomotorDetalle() { return ddhhMotivoAutomotorDetalle; }
+    public void setDdhhMotivoAutomotorDetalle(String ddhhMotivoAutomotorDetalle) { this.ddhhMotivoAutomotorDetalle = ddhhMotivoAutomotorDetalle; }
+    public String getDdhhMotivoCobroCreditoDetalle() { return ddhhMotivoCobroCreditoDetalle; }
+    public void setDdhhMotivoCobroCreditoDetalle(String ddhhMotivoCobroCreditoDetalle) { this.ddhhMotivoCobroCreditoDetalle = ddhhMotivoCobroCreditoDetalle; }
+    public String getDdhhMotivoOtroDetalle() { return ddhhMotivoOtroDetalle; }
+    public void setDdhhMotivoOtroDetalle(String ddhhMotivoOtroDetalle) { this.ddhhMotivoOtroDetalle = ddhhMotivoOtroDetalle; }
+    public String getDdhhPadreCausante() { return ddhhPadreCausante; }
+    public void setDdhhPadreCausante(String ddhhPadreCausante) { this.ddhhPadreCausante = ddhhPadreCausante; }
+    public String getDdhhMadreCausante() { return ddhhMadreCausante; }
+    public void setDdhhMadreCausante(String ddhhMadreCausante) { this.ddhhMadreCausante = ddhhMadreCausante; }
+    public String getDdhhObservaciones() { return ddhhObservaciones; }
+    public void setDdhhObservaciones(String ddhhObservaciones) { this.ddhhObservaciones = ddhhObservaciones; }
+    public String getUsuarioSac() { return usuarioSac; }
+    public void setUsuarioSac(String usuarioSac) { this.usuarioSac = usuarioSac; }
 
     public boolean equals(Object object) {
         // TODO: Warning - this method won't work in the case the id fields are not set

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -140,7 +140,56 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
+                                    <p:ajax update="ddhhPanel" />
                                     </p:selectOneMenu>
+                                    <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                        <div class="columna">
+                                            <p:outputLabel value="Causante:" for="ddhhCausante" />
+                                            <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
+                                            <p:outputLabel value="DNI:" for="ddhhDni" />
+                                            <p:inputText id="ddhhDni" value="#{expedienteController.selected.ddhhDni}" />
+                                            <p:outputLabel value="Último domicilio:" for="ddhhUltimoDomicilio" />
+                                            <p:inputText id="ddhhUltimoDomicilio" value="#{expedienteController.selected.ddhhUltimoDomicilio}" />
+                                            <p:outputLabel value="Estado Civil:" for="ddhhEstadoCivil" />
+                                            <p:inputText id="ddhhEstadoCivil" value="#{expedienteController.selected.ddhhEstadoCivil}" />
+                                            <p:outputLabel value="Herederos:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhHerederos}">
+                                                <f:selectItem itemLabel="Descendientes" itemValue="Descendientes" />
+                                                <f:selectItem itemLabel="Cónyuge" itemValue="Cónyuge" />
+                                                <f:selectItem itemLabel="Ascendientes" itemValue="Ascendientes" />
+                                                <f:selectItem itemLabel="Colaterales" itemValue="Colaterales" />
+                                            </p:selectManyCheckbox>
+                                            <p:inputTextarea value="#{expedienteController.selected.ddhhHerederosDetalle}" rows="4" cols="25" autoResize="false" />
+                                        </div>
+                                        <div class="columna">
+                                            <p:outputLabel value="Motivo DDHH:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
+                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
+                                                <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
+                                                <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                            </p:selectManyCheckbox>
+                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
+                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
+                                            <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
+                                            <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />
+                                            <p:inputText id="ddhhMadreCausante" value="#{expedienteController.selected.ddhhMadreCausante}" />
+                                            <p:outputLabel value="Observaciones DDHH:" for="ddhhObservaciones" />
+                                            <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
+                                        </div>
+                                    </h:panelGroup>
+
 
                                     </div>
 
@@ -188,6 +237,12 @@
                                     <p:outputLabel class="float-l" value="Responsable:" for="responsable" style="font-weight: bold"/>
                                     <p:selectOneMenu required="true" style="margin-left: 1%; margin-right: 1%" requiredMessage="debe seleccionar un responsable correcto" id="responsable" value="#{expedienteController.selected.responsable}">
                                         <f:selectItem itemLabel=" -- Elige un Responsable --"  noSelectionOption="true"  />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                    </p:selectOneMenu>
+
+                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac"/>
+                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
+                                        <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
                                         <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                     </p:selectOneMenu>
 

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -99,7 +99,56 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
+                                    <p:ajax update="ddhhPanel" />
                                     </p:selectOneMenu>
+                                    <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                        <div class="columna">
+                                            <p:outputLabel value="Causante:" for="ddhhCausante" />
+                                            <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
+                                            <p:outputLabel value="DNI:" for="ddhhDni" />
+                                            <p:inputText id="ddhhDni" value="#{expedienteController.selected.ddhhDni}" />
+                                            <p:outputLabel value="Último domicilio:" for="ddhhUltimoDomicilio" />
+                                            <p:inputText id="ddhhUltimoDomicilio" value="#{expedienteController.selected.ddhhUltimoDomicilio}" />
+                                            <p:outputLabel value="Estado Civil:" for="ddhhEstadoCivil" />
+                                            <p:inputText id="ddhhEstadoCivil" value="#{expedienteController.selected.ddhhEstadoCivil}" />
+                                            <p:outputLabel value="Herederos:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhHerederos}">
+                                                <f:selectItem itemLabel="Descendientes" itemValue="Descendientes" />
+                                                <f:selectItem itemLabel="Cónyuge" itemValue="Cónyuge" />
+                                                <f:selectItem itemLabel="Ascendientes" itemValue="Ascendientes" />
+                                                <f:selectItem itemLabel="Colaterales" itemValue="Colaterales" />
+                                            </p:selectManyCheckbox>
+                                            <p:inputTextarea value="#{expedienteController.selected.ddhhHerederosDetalle}" rows="4" cols="25" autoResize="false" />
+                                        </div>
+                                        <div class="columna">
+                                            <p:outputLabel value="Motivo DDHH:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
+                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
+                                                <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
+                                                <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                            </p:selectManyCheckbox>
+                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
+                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
+                                            <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
+                                            <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />
+                                            <p:inputText id="ddhhMadreCausante" value="#{expedienteController.selected.ddhhMadreCausante}" />
+                                            <p:outputLabel value="Observaciones DDHH:" for="ddhhObservaciones" />
+                                            <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
+                                        </div>
+                                    </h:panelGroup>
+
 
                             </h:panelGrid>
                             <h:panelGrid columns="2" cellspacing="5">
@@ -155,6 +204,12 @@
                                     <f:selectItem itemLabel=" -- Elige un Responsable --"  noSelectionOption="true"  />
                                     <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                 </p:selectOneMenu>
+
+                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac"/>
+                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
+                                        <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                    </p:selectOneMenu>
                             <br></br><br></br>
                                 <p:outputLabel value="Expediente físico:" for="fisico" style="font-weight: bold"/>
                                 <p:selectOneMenu id="fisico" value="#{expedienteController.selected.fisico}">

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -370,7 +370,56 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
+                                    <p:ajax update="ddhhPanel" />
                                     </p:selectOneMenu>
+                                    <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                        <div class="columna">
+                                            <p:outputLabel value="Causante:" for="ddhhCausante" />
+                                            <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
+                                            <p:outputLabel value="DNI:" for="ddhhDni" />
+                                            <p:inputText id="ddhhDni" value="#{expedienteController.selected.ddhhDni}" />
+                                            <p:outputLabel value="Último domicilio:" for="ddhhUltimoDomicilio" />
+                                            <p:inputText id="ddhhUltimoDomicilio" value="#{expedienteController.selected.ddhhUltimoDomicilio}" />
+                                            <p:outputLabel value="Estado Civil:" for="ddhhEstadoCivil" />
+                                            <p:inputText id="ddhhEstadoCivil" value="#{expedienteController.selected.ddhhEstadoCivil}" />
+                                            <p:outputLabel value="Herederos:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhHerederos}">
+                                                <f:selectItem itemLabel="Descendientes" itemValue="Descendientes" />
+                                                <f:selectItem itemLabel="Cónyuge" itemValue="Cónyuge" />
+                                                <f:selectItem itemLabel="Ascendientes" itemValue="Ascendientes" />
+                                                <f:selectItem itemLabel="Colaterales" itemValue="Colaterales" />
+                                            </p:selectManyCheckbox>
+                                            <p:inputTextarea value="#{expedienteController.selected.ddhhHerederosDetalle}" rows="4" cols="25" autoResize="false" />
+                                        </div>
+                                        <div class="columna">
+                                            <p:outputLabel value="Motivo DDHH:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
+                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
+                                                <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
+                                                <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                            </p:selectManyCheckbox>
+                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
+                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
+                                            <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
+                                            <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />
+                                            <p:inputText id="ddhhMadreCausante" value="#{expedienteController.selected.ddhhMadreCausante}" />
+                                            <p:outputLabel value="Observaciones DDHH:" for="ddhhObservaciones" />
+                                            <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
+                                        </div>
+                                    </h:panelGroup>
+
 
 
 
@@ -409,6 +458,12 @@
                                         <f:selectItem itemLabel="Mateo Francisco Alvarez" itemValue="Mateo Francisco Alvarez" />
                                         <f:selectItem itemLabel="María Emilia Campos" itemValue="María Emilia Campos" />
                                         <f:selectItem itemLabel="María Paz Bolinaga" itemValue="María Paz Bolinaga" />
+                                    </p:selectOneMenu>
+
+                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac"/>
+                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
+                                        <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                     </p:selectOneMenu>
                                 </div>
                                 <div class="columna">

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -355,7 +355,56 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
+                                    <p:ajax update="ddhhPanel" />
                                     </p:selectOneMenu>
+                                    <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                        <div class="columna">
+                                            <p:outputLabel value="Causante:" for="ddhhCausante" />
+                                            <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
+                                            <p:outputLabel value="DNI:" for="ddhhDni" />
+                                            <p:inputText id="ddhhDni" value="#{expedienteController.selected.ddhhDni}" />
+                                            <p:outputLabel value="Último domicilio:" for="ddhhUltimoDomicilio" />
+                                            <p:inputText id="ddhhUltimoDomicilio" value="#{expedienteController.selected.ddhhUltimoDomicilio}" />
+                                            <p:outputLabel value="Estado Civil:" for="ddhhEstadoCivil" />
+                                            <p:inputText id="ddhhEstadoCivil" value="#{expedienteController.selected.ddhhEstadoCivil}" />
+                                            <p:outputLabel value="Herederos:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhHerederos}">
+                                                <f:selectItem itemLabel="Descendientes" itemValue="Descendientes" />
+                                                <f:selectItem itemLabel="Cónyuge" itemValue="Cónyuge" />
+                                                <f:selectItem itemLabel="Ascendientes" itemValue="Ascendientes" />
+                                                <f:selectItem itemLabel="Colaterales" itemValue="Colaterales" />
+                                            </p:selectManyCheckbox>
+                                            <p:inputTextarea value="#{expedienteController.selected.ddhhHerederosDetalle}" rows="4" cols="25" autoResize="false" />
+                                        </div>
+                                        <div class="columna">
+                                            <p:outputLabel value="Motivo DDHH:" />
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
+                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
+                                                <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
+                                                <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                            </p:selectManyCheckbox>
+                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
+                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
+                                            <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
+                                            <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />
+                                            <p:inputText id="ddhhMadreCausante" value="#{expedienteController.selected.ddhhMadreCausante}" />
+                                            <p:outputLabel value="Observaciones DDHH:" for="ddhhObservaciones" />
+                                            <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
+                                        </div>
+                                    </h:panelGroup>
+
 
                                 <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
                                     <p:commandButton value="Si" type="button" styleClass="ui-confirmdialog-no" icon="pi pi-times" update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm" />
@@ -461,6 +510,12 @@
 
                                 <p:selectOneMenu requiredMessage="debe seleccionar un responsable correcto" id="responsable" value="#{expedienteController.selected.responsable}">
                                     <f:selectItem itemLabel=" -- Elige un Responsable --"  noSelectionOption="true"  />
+                                    <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                </p:selectOneMenu>
+
+                                <p:outputLabel class="" value="Usuario SAC:" for="usuarioSac" />
+                                <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
+                                    <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
                                     <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                 </p:selectOneMenu>
 


### PR DESCRIPTION
### Motivation
- Permitir registrar datos específicos cuando `JP Tipo` sea `DDHH` en expedientes administrativos (y mostrar además en judicial), y poder asignar un `Usuario SAC` (empleado) al expediente. 

### Description
- Se agregaron campos persistidos en la entidad `Expediente` para DDHH y `usuarioSac` (`src/java/com/estudioAlvarezVersion2/jpa/Expediente.java`) con sus getters/setters. 
- Se añadió el script de migración `ALTER_TABLE_EXPEDIENTE_ADD_DDHH.sql` para crear las columnas nuevas en la tabla `Expediente`. 
- En los formularios de alta/edición (`web/expediente/Create.xhtml`, `web/expediente/Edit.xhtml`, `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/EditExpJudicial.xhtml`) se agregó un `p:ajax` sobre `jpTipo` y un panel condicionally mostrado (`ddhhPanel`) que contiene los campos solicitados (Causante, DNI, Último domicilio, Estado Civil, Herederos + detalle, Motivo DDHH con opciones y campos de detalle, Padre, Madre, Observaciones). 
- Se incorporó un `selectOneMenu` `Usuario SAC` poblado desde `empleadoController.items` en los formularios para elegir el abogado/empleado responsable del SAC; no se modificaron los `*List.xhtml`.

### Testing
- Se validó que los archivos XHTML modificados parsean como XML usando Python `xml.etree.ElementTree.parse`, y la comprobación fue exitosa. 
- Intento de compilación con `ant -q compile` falló porque `ant` no está instalado en el entorno de ejecución (error de herramienta, no del código). 
- No se ejecutaron pruebas de base de datos; se incluye el script `ALTER_TABLE_EXPEDIENTE_ADD_DDHH.sql` para aplicar las modificaciones del esquema en el entorno de despliegue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a326d04eedc8327802b30dc8f23fdc7)