### PR TITLE
Fix DDHH multi-select persistence mapping

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -309,13 +309,13 @@ public class Expediente implements Serializable {
     private String ddhhEstadoCivil;
 
     @Column(name = "ddhhHerederos")
-    private String[] ddhhHerederos;
+    private String ddhhHerederos;
 
     @Column(name = "ddhhHerederosDetalle")
     private String ddhhHerederosDetalle;
 
     @Column(name = "ddhhMotivos")
-    private String[] ddhhMotivos;
+    private String ddhhMotivos;
 
     @Column(name = "ddhhMotivoInmuebleDetalle")
     private String ddhhMotivoInmuebleDetalle;
@@ -998,12 +998,12 @@ public class Expediente implements Serializable {
     public void setDdhhUltimoDomicilio(String ddhhUltimoDomicilio) { this.ddhhUltimoDomicilio = ddhhUltimoDomicilio; }
     public String getDdhhEstadoCivil() { return ddhhEstadoCivil; }
     public void setDdhhEstadoCivil(String ddhhEstadoCivil) { this.ddhhEstadoCivil = ddhhEstadoCivil; }
-    public String[] getDdhhHerederos() { return ddhhHerederos; }
-    public void setDdhhHerederos(String[] ddhhHerederos) { this.ddhhHerederos = ddhhHerederos; }
+    public String[] getDdhhHerederos() { return convertirTextoAArray(ddhhHerederos); }
+    public void setDdhhHerederos(String[] ddhhHerederos) { this.ddhhHerederos = convertirArrayATexto(ddhhHerederos); }
     public String getDdhhHerederosDetalle() { return ddhhHerederosDetalle; }
     public void setDdhhHerederosDetalle(String ddhhHerederosDetalle) { this.ddhhHerederosDetalle = ddhhHerederosDetalle; }
-    public String[] getDdhhMotivos() { return ddhhMotivos; }
-    public void setDdhhMotivos(String[] ddhhMotivos) { this.ddhhMotivos = ddhhMotivos; }
+    public String[] getDdhhMotivos() { return convertirTextoAArray(ddhhMotivos); }
+    public void setDdhhMotivos(String[] ddhhMotivos) { this.ddhhMotivos = convertirArrayATexto(ddhhMotivos); }
     public String getDdhhMotivoInmuebleDetalle() { return ddhhMotivoInmuebleDetalle; }
     public void setDdhhMotivoInmuebleDetalle(String ddhhMotivoInmuebleDetalle) { this.ddhhMotivoInmuebleDetalle = ddhhMotivoInmuebleDetalle; }
     public String getDdhhMotivoAutomotorDetalle() { return ddhhMotivoAutomotorDetalle; }
@@ -1012,6 +1012,20 @@ public class Expediente implements Serializable {
     public void setDdhhMotivoCobroCreditoDetalle(String ddhhMotivoCobroCreditoDetalle) { this.ddhhMotivoCobroCreditoDetalle = ddhhMotivoCobroCreditoDetalle; }
     public String getDdhhMotivoOtroDetalle() { return ddhhMotivoOtroDetalle; }
     public void setDdhhMotivoOtroDetalle(String ddhhMotivoOtroDetalle) { this.ddhhMotivoOtroDetalle = ddhhMotivoOtroDetalle; }
+    private String[] convertirTextoAArray(String valor) {
+        if (valor == null || valor.trim().isEmpty()) {
+            return new String[0];
+        }
+        return valor.split("\\|");
+    }
+
+    private String convertirArrayATexto(String[] valores) {
+        if (valores == null || valores.length == 0) {
+            return null;
+        }
+        return String.join("|", valores);
+    }
+
     public String getDdhhPadreCausante() { return ddhhPadreCausante; }
     public void setDdhhPadreCausante(String ddhhPadreCausante) { this.ddhhPadreCausante = ddhhPadreCausante; }
     public String getDdhhMadreCausante() { return ddhhMadreCausante; }


### PR DESCRIPTION
### Motivation
- Fix an EclipseLink `ConversionException` caused by mapping Java `String[]` fields directly to `VARCHAR` columns which produced conversion errors when reading persisted rows.
- Preserve existing JSF `p:selectManyCheckbox` bindings that expect `String[]` while making the JPA mapping compatible with the current DB schema.

### Description
- Changed the JPA fields `ddhhHerederos` and `ddhhMotivos` from `String[]` to `String` in `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java` so values are stored as delimited text in the existing `VARCHAR` columns.
- Kept the public getters/setters signature as `String[]` and added conversion logic so getters return `String[]` and setters accept `String[]` but persist a `String` using a `|` delimiter.
- Added two helper methods `convertirTextoAArray` and `convertirArrayATexto` to perform the conversion between the delimited text and arrays.

### Testing
- Ran `git diff --check` which reported no whitespace/patch problems and completed successfully.
- Attempted to run a full build with `ant -q clean jar` but it failed because `ant` is not installed in the environment, so no binary build/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34c6ddc2b8832795ea8b6db3d1f794)