### PR TITLE
Reordenar campos DDHH en expedientes judiciales

### DIFF
--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -336,6 +336,13 @@
                         <div class="datosexpediente">
                             <div class="columna">
 
+                                <p:outputLabel value="Equipo:" for="equipo"  />
+
+                                <p:selectOneMenu  id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
+                                    <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
+                                    <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
+                                </p:selectOneMenu>
+
                                 <p:outputLabel value="Tipo:" for="tipo" />
                                 <p:selectOneMenu   editable="true" id="tipo"  value="#{expedienteController.selected.tipo}" >
                                     <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
@@ -357,51 +364,57 @@
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="ddhhPanel" />
                                     </p:selectOneMenu>
-                                    <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
-                                        <div class="columna">
-                                            <p:outputLabel value="Causante:" for="ddhhCausante" />
-                                            <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
-                                            <p:outputLabel value="DNI:" for="ddhhDni" />
-                                            <p:inputText id="ddhhDni" value="#{expedienteController.selected.ddhhDni}" />
-                                            <p:outputLabel value="Último domicilio:" for="ddhhUltimoDomicilio" />
-                                            <p:inputText id="ddhhUltimoDomicilio" value="#{expedienteController.selected.ddhhUltimoDomicilio}" />
-                                            <p:outputLabel value="Estado Civil:" for="ddhhEstadoCivil" />
-                                            <p:inputText id="ddhhEstadoCivil" value="#{expedienteController.selected.ddhhEstadoCivil}" />
-                                            <p:outputLabel value="Herederos:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhHerederos}">
-                                                <f:selectItem itemLabel="Descendientes" itemValue="Descendientes" />
-                                                <f:selectItem itemLabel="Cónyuge" itemValue="Cónyuge" />
-                                                <f:selectItem itemLabel="Ascendientes" itemValue="Ascendientes" />
-                                                <f:selectItem itemLabel="Colaterales" itemValue="Colaterales" />
-                                            </p:selectManyCheckbox>
-                                            <p:inputTextarea value="#{expedienteController.selected.ddhhHerederosDetalle}" rows="4" cols="25" autoResize="false" />
-                                        </div>
-                                        <div class="columna">
-                                            <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
-                                                <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
-                                                <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
-                                                <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
-                                                <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                            </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
-                                            <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
-                                            <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
-                                            <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />
-                                            <p:inputText id="ddhhMadreCausante" value="#{expedienteController.selected.ddhhMadreCausante}" />
-                                            <p:outputLabel value="Observaciones DDHH:" for="ddhhObservaciones" />
-                                            <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
+                                    <h:panelGroup id="ddhhPanel" layout="block" styleClass="ddhh-panel" style="display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                        <div class="ddhh-layout">
+                                            <div class="ddhh-col ddhh-causante">
+                                                <p:outputLabel value="Causante:" for="ddhhCausante" />
+                                                <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
+                                                <p:outputLabel value="DNI:" for="ddhhDni" />
+                                                <p:inputText id="ddhhDni" value="#{expedienteController.selected.ddhhDni}" />
+                                                <p:outputLabel value="Último Domicilio:" for="ddhhUltimoDomicilio" />
+                                                <p:inputText id="ddhhUltimoDomicilio" value="#{expedienteController.selected.ddhhUltimoDomicilio}" />
+                                                <p:outputLabel value="Estado Civil:" for="ddhhEstadoCivil" />
+                                                <p:inputText id="ddhhEstadoCivil" value="#{expedienteController.selected.ddhhEstadoCivil}" />
+                                                <p:outputLabel value="Herederos:" />
+                                                <div class="ddhh-herederos">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhHerederos}">
+                                                        <f:selectItem itemLabel="Descendientes" itemValue="Descendientes" />
+                                                        <f:selectItem itemLabel="Cónyuge" itemValue="Cónyuge" />
+                                                        <f:selectItem itemLabel="Ascendientes" itemValue="Ascendientes" />
+                                                        <f:selectItem itemLabel="Colaterales" itemValue="Colaterales" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:inputTextarea value="#{expedienteController.selected.ddhhHerederosDetalle}" rows="4" cols="25" autoResize="false" />
+                                                </div>
+                                            </div>
+                                            <div class="ddhh-col ddhh-motivos">
+                                                <p:outputLabel value="Motivo DDHH:" />
+                                                <div class="ddhh-motivo-grilla">
+                                                    <p:selectManyCheckbox layout="grid" columns="3" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
+                                                        <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
+                                                        <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                                    </p:selectManyCheckbox>
+                                                </div>
+                                                <p:outputLabel value="Nº cta RENTAS:" for="ddhhMotivoInmuebleDetalle" />
+                                                <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                <p:outputLabel value="Patente:" for="ddhhMotivoAutomotorDetalle" />
+                                                <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
+                                                <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
+                                                <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />
+                                                <p:inputText id="ddhhMadreCausante" value="#{expedienteController.selected.ddhhMadreCausante}" />
+                                                <p:outputLabel value="Observaciones:" for="ddhhObservaciones" />
+                                                <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
+                                            </div>
                                         </div>
                                     </h:panelGroup>
 
@@ -409,12 +422,6 @@
                                 <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
                                     <p:commandButton value="Si" type="button" styleClass="ui-confirmdialog-no" icon="pi pi-times" update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm" />
                                 </p:confirmDialog>
-                                <p:outputLabel value="Equipo:" for="equipo"  />
-
-                                <p:selectOneMenu  id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
-                                    <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
-                                    <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
-                                </p:selectOneMenu>
                                 <div class="checkboxexpedientes">
 
                                     <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.subCategoriasDeTipo}"  rendered="#{expedienteController.selected.tipo eq 'Reajustes'}" >

--- a/web/resources/css/jsfcrud.css
+++ b/web/resources/css/jsfcrud.css
@@ -1820,3 +1820,40 @@ display: flex;
   overflow-wrap: anywhere;
   line-height: 1.25rem;
 }
+
+/* Reordenamiento visual para expediente judicial con JP Tipo DDHH */
+.ddhh-panel {
+    width: 100%;
+    margin-top: 15px;
+}
+
+.ddhh-layout {
+    display: grid;
+    grid-template-columns: minmax(230px, 1fr) minmax(260px, 1fr);
+    gap: 35px;
+}
+
+.ddhh-col {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.ddhh-herederos {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 10px;
+    align-items: start;
+}
+
+.ddhh-motivo-grilla .ui-selectmanycheckbox td {
+    padding-right: 12px;
+    white-space: nowrap;
+}
+
+.ddhh-col input,
+.ddhh-col textarea,
+.ddhh-col .ui-inputfield {
+    width: 100%;
+    box-sizing: border-box;
+}

--- a/web/resources/css/jsfcrud.css
+++ b/web/resources/css/jsfcrud.css
@@ -1824,13 +1824,23 @@ display: flex;
 /* Reordenamiento visual para expediente judicial con JP Tipo DDHH */
 .ddhh-panel {
     width: 100%;
+    max-width: 100%;
     margin-top: 15px;
+    overflow-wrap: anywhere;
 }
 
 .ddhh-layout {
     display: grid;
-    grid-template-columns: minmax(230px, 1fr) minmax(260px, 1fr);
-    gap: 35px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 20px;
+    max-width: 100%;
+}
+
+@media (min-width: 1500px) {
+    .ddhh-layout {
+        grid-template-columns: minmax(230px, 1fr) minmax(260px, 1fr);
+        gap: 35px;
+    }
 }
 
 .ddhh-col {
@@ -1844,6 +1854,13 @@ display: flex;
     grid-template-columns: auto 1fr;
     gap: 10px;
     align-items: start;
+    max-width: 100%;
+}
+
+@media (max-width: 1200px) {
+    .ddhh-herederos {
+        grid-template-columns: 1fr;
+    }
 }
 
 .ddhh-motivo-grilla .ui-selectmanycheckbox td {


### PR DESCRIPTION
### Motivation
- Ajustar la disposición visual del formulario de expediente judicial para que, cuando `JP Tipo` sea `DDHH`, los campos relevantes queden ordenados como en la referencia fotográfica (mover elementos de lugar sin cambiar lógica de negocio). 
- Facilitar el ingreso de datos DDHH agrupando información del causante/herederos y los motivos/detalles en bloques claros.

### Description
- En `web/expediente/EditExpJudicial.xhtml` se movió el bloque `Equipo` arriba del campo `Tipo` y se reordenaron los controles de `Tipo` y `JP Tipo` para quedar por encima del panel DDHH; además se eliminó la aparición duplicada del selector `Equipo`. 
- El panel DDHH (`h:panelGroup id="ddhhPanel"`) ahora tiene una estructura en dos columnas con clases nuevas (`ddhh-panel`, `ddhh-layout`, `ddhh-col`, `ddhh-herederos`, `ddhh-motivo-grilla`) y reorganiza inputs/checkboxes (herederos en bloque y motivos en grilla de 3 columnas) y etiquetas (`Nº cta RENTAS`, `Patente`, `Observaciones`, etc.).
- Se actualizaron estilos en `web/resources/css/jsfcrud.css` para soportar la nueva disposición (grid interno, separación entre columnas, ajuste de anchura para inputs y textareas).

### Testing
- Se validó programáticamente que el XML del archivo modificado es parseable con `python3 - <<'PY' ... ET.parse(Path('web/expediente/EditExpJudicial.xhtml')) ... PY`, y el parseo devolvió `XML OK` (éxito). 
- Se intentó ejecutar `xmllint --noout web/expediente/EditExpJudicial.xhtml` pero la utilidad no está disponible en el entorno (falló por ausencia de la herramienta).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a0b56f9b48327b272722b510ecf63)