### PR TITLE
Ajustar visualización condicional de Motivo DDHH

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -1004,6 +1004,21 @@ public class Expediente implements Serializable {
     public void setDdhhHerederosDetalle(String ddhhHerederosDetalle) { this.ddhhHerederosDetalle = ddhhHerederosDetalle; }
     public String[] getDdhhMotivos() { return convertirTextoAArray(ddhhMotivos); }
     public void setDdhhMotivos(String[] ddhhMotivos) { this.ddhhMotivos = convertirArrayATexto(ddhhMotivos); }
+    public String[] getDdhhMotivosPrincipales() { return filtrarDdhhMotivos(true); }
+    public void setDdhhMotivosPrincipales(String[] ddhhMotivosPrincipales) {
+        this.ddhhMotivos = convertirArrayATexto(unirArrays(ddhhMotivosPrincipales, getDdhhMotivosOpciones()));
+    }
+    public String[] getDdhhMotivosOpciones() { return filtrarDdhhMotivos(false); }
+    public void setDdhhMotivosOpciones(String[] ddhhMotivosOpciones) {
+        this.ddhhMotivos = convertirArrayATexto(unirArrays(getDdhhMotivosPrincipales(), ddhhMotivosOpciones));
+    }
+    public boolean isDdhhMotivoInmuebleSelected() { return tieneDdhhMotivo("Inmueble"); }
+    public boolean isDdhhMotivoAutomotorSelected() { return tieneDdhhMotivo("Automotor"); }
+    public boolean isDdhhMotivoBienRegistrableSelected() {
+        return isDdhhMotivoInmuebleSelected() || isDdhhMotivoAutomotorSelected();
+    }
+    public boolean isDdhhMotivoCobroCreditoSelected() { return tieneDdhhMotivo("Cobro de crédito"); }
+    public boolean isDdhhMotivoOtroSelected() { return tieneDdhhMotivo("Otro"); }
     public String getDdhhMotivoInmuebleDetalle() { return ddhhMotivoInmuebleDetalle; }
     public void setDdhhMotivoInmuebleDetalle(String ddhhMotivoInmuebleDetalle) { this.ddhhMotivoInmuebleDetalle = ddhhMotivoInmuebleDetalle; }
     public String getDdhhMotivoAutomotorDetalle() { return ddhhMotivoAutomotorDetalle; }
@@ -1012,6 +1027,43 @@ public class Expediente implements Serializable {
     public void setDdhhMotivoCobroCreditoDetalle(String ddhhMotivoCobroCreditoDetalle) { this.ddhhMotivoCobroCreditoDetalle = ddhhMotivoCobroCreditoDetalle; }
     public String getDdhhMotivoOtroDetalle() { return ddhhMotivoOtroDetalle; }
     public void setDdhhMotivoOtroDetalle(String ddhhMotivoOtroDetalle) { this.ddhhMotivoOtroDetalle = ddhhMotivoOtroDetalle; }
+    private boolean tieneDdhhMotivo(String motivo) {
+        for (String ddhhMotivo : getDdhhMotivos()) {
+            if (motivo.equals(ddhhMotivo)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    private String[] filtrarDdhhMotivos(boolean principales) {
+        java.util.List<String> motivosFiltrados = new java.util.ArrayList<String>();
+        for (String motivo : getDdhhMotivos()) {
+            if (esDdhhMotivoPrincipal(motivo) == principales) {
+                motivosFiltrados.add(motivo);
+            }
+        }
+        return motivosFiltrados.toArray(new String[motivosFiltrados.size()]);
+    }
+    private boolean esDdhhMotivoPrincipal(String motivo) {
+        return "Inmueble".equals(motivo) || "Automotor".equals(motivo)
+                || "Cobro de crédito".equals(motivo) || "Otro".equals(motivo);
+    }
+    private String[] unirArrays(String[] primeros, String[] segundos) {
+        java.util.List<String> motivosUnidos = new java.util.ArrayList<String>();
+        agregarMotivos(motivosUnidos, primeros);
+        agregarMotivos(motivosUnidos, segundos);
+        return motivosUnidos.toArray(new String[motivosUnidos.size()]);
+    }
+    private void agregarMotivos(java.util.List<String> motivos, String[] nuevosMotivos) {
+        if (nuevosMotivos == null) {
+            return;
+        }
+        for (String motivo : nuevosMotivos) {
+            if (motivo != null && !motivo.trim().isEmpty() && !motivos.contains(motivo)) {
+                motivos.add(motivo);
+            }
+        }
+    }
     private String[] convertirTextoAArray(String valor) {
         if (valor == null || valor.trim().isEmpty()) {
             return new String[0];

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -163,24 +163,40 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                                <p:ajax update="ddhhMotivosDetallePanel" />
                                             </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <h:panelGroup id="ddhhMotivosDetallePanel" layout="block">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoBienRegistrableSelected}">
+                                                    <p:outputLabel value="Opciones inmueble / automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosOpciones}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSelected}">
+                                                    <p:outputLabel value="NUMERO DE CUENTA – RENTAS:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSelected}">
+                                                    <p:outputLabel value="PATENTE:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSelected}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSelected}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -122,24 +122,40 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                                <p:ajax update="ddhhMotivosDetallePanel" />
                                             </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <h:panelGroup id="ddhhMotivosDetallePanel" layout="block">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoBienRegistrableSelected}">
+                                                    <p:outputLabel value="Opciones inmueble / automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosOpciones}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSelected}">
+                                                    <p:outputLabel value="NUMERO DE CUENTA – RENTAS:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSelected}">
+                                                    <p:outputLabel value="PATENTE:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSelected}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSelected}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -393,24 +393,40 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                                <p:ajax update="ddhhMotivosDetallePanel" />
                                             </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <h:panelGroup id="ddhhMotivosDetallePanel" layout="block">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoBienRegistrableSelected}">
+                                                    <p:outputLabel value="Opciones inmueble / automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosOpciones}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSelected}">
+                                                    <p:outputLabel value="NUMERO DE CUENTA – RENTAS:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSelected}">
+                                                    <p:outputLabel value="PATENTE:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSelected}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSelected}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -378,24 +378,40 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
+                                                <p:ajax update="ddhhMotivosDetallePanel" />
                                             </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                            <h:panelGroup id="ddhhMotivosDetallePanel" layout="block">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoBienRegistrableSelected}">
+                                                    <p:outputLabel value="Opciones inmueble / automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosOpciones}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSelected}">
+                                                    <p:outputLabel value="NUMERO DE CUENTA – RENTAS:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSelected}">
+                                                    <p:outputLabel value="PATENTE:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSelected}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSelected}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />


### PR DESCRIPTION
### Motivation
- Simplificar la carga de datos en el módulo Declaratoria de Herederos mostrando inicialmente solo las opciones principales del campo “Motivo” (Inmueble, Automotor, Cobro de crédito, Otro). 
- Evitar mostrar campos no aplicables mostrando condicionalmente las opciones y campos asociados según el motivo seleccionado. 

### Description
- Modifica las vistas `web/expediente/Create.xhtml`, `web/expediente/Edit.xhtml`, `web/expediente/CreateExpJudicial.xhtml` y `web/expediente/EditExpJudicial.xhtml` para que el `Motivo DDHH` muestre únicamente las opciones principales y agregue un `p:ajax` que actualiza un panel de detalles (`ddhhMotivosDetallePanel`).
- Añade dentro del panel de detalles renderizados condicionales que muestran: opciones `Ganancial/Propio/Venta/Adjudicación` cuando el motivo es `Inmueble` o `Automotor`, el campo `NUMERO DE CUENTA – RENTAS` para `Inmueble`, el campo `PATENTE` para `Automotor`, y campos de texto libre para `Cobro de crédito` y `Otro`.
- Agrega métodos auxiliares en `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java` para separar motivos principales y opciones (`getDdhhMotivosPrincipales`, `getDdhhMotivosOpciones`) y para evaluar la visibilidad (`isDdhhMotivoInmuebleSelected`, `isDdhhMotivoAutomotorSelected`, `isDdhhMotivoBienRegistrableSelected`, `isDdhhMotivoCobroCreditoSelected`, `isDdhhMotivoOtroSelected`) sin alterar la persistencia existente.
- Implementa utilidades internas en `Expediente` para filtrar y unir arrays de motivos y comprobar la presencia de un motivo seleccionando de manera consistente la presentación en la UI.

### Testing
- Se ejecutó `git diff --check` y no se detectaron problemas de diff/espacios en blanco (éxito).
- Se intentó ejecutar `ant -q build` pero falló porque `ant` no está instalado en el entorno de ejecución (no se pudo completar la build).
- Se intentó ejecutar `xmllint --noout` contra las vistas XHMTL pero `xmllint` no está disponible en el entorno (no se pudo validar los XML).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad5ce7a648327829f47ce6e04d410)