### PR TITLE
Ajustar visualización condicional de Motivo DDHH

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -1004,6 +1004,47 @@ public class Expediente implements Serializable {
     public void setDdhhHerederosDetalle(String ddhhHerederosDetalle) { this.ddhhHerederosDetalle = ddhhHerederosDetalle; }
     public String[] getDdhhMotivos() { return convertirTextoAArray(ddhhMotivos); }
     public void setDdhhMotivos(String[] ddhhMotivos) { this.ddhhMotivos = convertirArrayATexto(ddhhMotivos); }
+    public String getDdhhMotivoPrincipal() {
+        for (String motivo : getDdhhMotivos()) {
+            if (esDdhhMotivoPrincipal(motivo)) {
+                return motivo;
+            }
+        }
+        return null;
+    }
+
+    public void setDdhhMotivoPrincipal(String ddhhMotivoPrincipal) {
+        java.util.List<String> motivos = new java.util.ArrayList<String>();
+        if (ddhhMotivoPrincipal != null && !ddhhMotivoPrincipal.trim().isEmpty()) {
+            motivos.add(ddhhMotivoPrincipal);
+        }
+        for (String motivo : getDdhhMotivos()) {
+            if (motivo != null && !esDdhhMotivoPrincipal(motivo)) {
+                motivos.add(motivo);
+            }
+        }
+        setDdhhMotivos(motivos.toArray(new String[motivos.size()]));
+    }
+
+    private boolean esDdhhMotivoPrincipal(String motivo) {
+        return motivo != null && (motivo.equalsIgnoreCase("Inmueble")
+                || motivo.equalsIgnoreCase("Automotor")
+                || motivo.equalsIgnoreCase("Cobro de crédito")
+                || motivo.equalsIgnoreCase("Otro"));
+    }
+    public boolean isDdhhMotivoInmuebleSeleccionado() { return contieneDdhhMotivo("Inmueble"); }
+    public boolean isDdhhMotivoAutomotorSeleccionado() { return contieneDdhhMotivo("Automotor"); }
+    public boolean isDdhhMotivoCobroCreditoSeleccionado() { return contieneDdhhMotivo("Cobro de crédito"); }
+    public boolean isDdhhMotivoOtroSeleccionado() { return contieneDdhhMotivo("Otro"); }
+
+    private boolean contieneDdhhMotivo(String motivo) {
+        for (String ddhhMotivo : getDdhhMotivos()) {
+            if (ddhhMotivo != null && ddhhMotivo.trim().equalsIgnoreCase(motivo)) {
+                return true;
+            }
+        }
+        return false;
+    }
     public String getDdhhMotivoInmuebleDetalle() { return ddhhMotivoInmuebleDetalle; }
     public void setDdhhMotivoInmuebleDetalle(String ddhhMotivoInmuebleDetalle) { this.ddhhMotivoInmuebleDetalle = ddhhMotivoInmuebleDetalle; }
     public String getDdhhMotivoAutomotorDetalle() { return ddhhMotivoAutomotorDetalle; }

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -163,24 +163,45 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectOneRadio id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                            </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                <p:ajax update="ddhhMotivosDetalle" />
+                                            </p:selectOneRadio>
+                                            <h:panelGroup id="ddhhMotivosDetalle" layout="block">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
+                                                    <p:outputLabel value="Opciones inmueble:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Número de cuenta - Rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
+                                                    <p:outputLabel value="Opciones automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Patente:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSeleccionado}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSeleccionado}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -122,24 +122,45 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectOneRadio id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                            </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                <p:ajax update="ddhhMotivosDetalle" />
+                                            </p:selectOneRadio>
+                                            <h:panelGroup id="ddhhMotivosDetalle" layout="block">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
+                                                    <p:outputLabel value="Opciones inmueble:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Número de cuenta - Rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
+                                                    <p:outputLabel value="Opciones automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Patente:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSeleccionado}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSeleccionado}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -393,24 +393,45 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectOneRadio id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                            </p:selectManyCheckbox>
-                                            <p:outputLabel value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                <p:ajax update="ddhhMotivosDetalle" />
+                                            </p:selectOneRadio>
+                                            <h:panelGroup id="ddhhMotivosDetalle" layout="block">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
+                                                    <p:outputLabel value="Opciones inmueble:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Número de cuenta - Rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
+                                                    <p:outputLabel value="Opciones automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Patente:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSeleccionado}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSeleccionado}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel value="Madre del Causante:" for="ddhhMadreCausante" />

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -404,24 +404,45 @@
                                         </div>
                             <div class="columna">
                                             <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Motivo DDHH:" />
-                                            <p:selectManyCheckbox rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                            <p:selectOneRadio rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
-                                                <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
-                                                <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
-                                                <f:selectItem itemLabel="Propio" itemValue="Propio" />
-                                                <f:selectItem itemLabel="Venta" itemValue="Venta" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                            </p:selectManyCheckbox>
-                                            <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Detalle inmueble / cuenta rentas:" for="ddhhMotivoInmuebleDetalle" />
-                                            <p:inputText rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
-                                            <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Detalle automotor / patente:" for="ddhhMotivoAutomotorDetalle" />
-                                            <p:inputText rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
-                                            <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
-                                            <p:inputTextarea rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
-                                            <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Otro:" for="ddhhMotivoOtroDetalle" />
-                                            <p:inputText rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                <p:ajax update="ddhhMotivosDetalle" />
+                                            </p:selectOneRadio>
+                                            <h:panelGroup id="ddhhMotivosDetalle" layout="block" rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}">
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
+                                                    <p:outputLabel value="Opciones inmueble:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Número de cuenta - Rentas:" for="ddhhMotivoInmuebleDetalle" />
+                                                    <p:inputText id="ddhhMotivoInmuebleDetalle" value="#{expedienteController.selected.ddhhMotivoInmuebleDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
+                                                    <p:outputLabel value="Opciones automotor:" />
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                        <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
+                                                        <f:selectItem itemLabel="Propio" itemValue="Propio" />
+                                                        <f:selectItem itemLabel="Venta" itemValue="Venta" />
+                                                        <f:selectItem itemLabel="Adjudicación" itemValue="Adjudicación" />
+                                                    </p:selectManyCheckbox>
+                                                    <p:outputLabel value="Patente:" for="ddhhMotivoAutomotorDetalle" />
+                                                    <p:inputText id="ddhhMotivoAutomotorDetalle" value="#{expedienteController.selected.ddhhMotivoAutomotorDetalle}" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoCobroCreditoSeleccionado}">
+                                                    <p:outputLabel value="Cobro de crédito:" for="ddhhMotivoCobroCreditoDetalle" />
+                                                    <p:inputTextarea id="ddhhMotivoCobroCreditoDetalle" value="#{expedienteController.selected.ddhhMotivoCobroCreditoDetalle}" rows="3" cols="30" autoResize="false" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoOtroSeleccionado}">
+                                                    <p:outputLabel value="Otro:" for="ddhhMotivoOtroDetalle" />
+                                                    <p:inputText id="ddhhMotivoOtroDetalle" value="#{expedienteController.selected.ddhhMotivoOtroDetalle}" />
+                                                </h:panelGroup>
+                                            </h:panelGroup>
                                             <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Padre del Causante:" for="ddhhPadreCausante" />
                                             <p:inputText rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhPadreCausante" value="#{expedienteController.selected.ddhhPadreCausante}" />
                                             <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Madre del Causante:" for="ddhhMadreCausante" />


### PR DESCRIPTION
### Motivation
- Simplificar la interfaz de ingreso para la sección `Motivo DDHH` mostrando solo las opciones principales inicialmente. 
- Evitar campos irrelevantes y mostrar detalles adicionales solo cuando correspondan al motivo seleccionado. 
- Mantener la persistencia actual de `ddhhMotivos` sin cambiar el esquema de datos.

### Description
- Reemplacé el selector múltiple por un selector principal único en los formularios `web/expediente/Create.xhtml`, `web/expediente/Edit.xhtml`, `web/expediente/CreateExpJudicial.xhtml` y `web/expediente/EditExpJudicial.xhtml` usando `p:selectOneRadio` ligado a `#{expedienteController.selected.ddhhMotivoPrincipal}` y limitando las opciones a `Inmueble`, `Automotor`, `Cobro de crédito` y `Otro`.
- Añadí un `p:ajax update="ddhhMotivosDetalle"` y un `h:panelGroup id="ddhhMotivosDetalle"` que despliega condicionalmente subpaneles para cada motivo principal con sus campos específicos (opciones `Ganancial/Propio/Venta/Adjudicación` y campos `ddhhMotivoInmuebleDetalle` / `ddhhMotivoAutomotorDetalle` o textareas para `Cobro de crédito` y `Otro`).
- Mantengo internamente los motivos secundarios como `ddhhMotivos` (selector múltiple) dentro de los subpaneles cuando corresponda, para preservar la compatibilidad con la persistencia existente.
- Agregué helpers en `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java`: `getDdhhMotivoPrincipal`, `setDdhhMotivoPrincipal`, `esDdhhMotivoPrincipal`, `isDdhhMotivoInmuebleSeleccionado`, `isDdhhMotivoAutomotorSeleccionado`, `isDdhhMotivoCobroCreditoSeleccionado`, `isDdhhMotivoOtroSeleccionado` y `contieneDdhhMotivo` para resolver el motivo principal y controlar la renderización condicional sin alterar el almacenamiento de `ddhhMotivos`.

### Testing
- Ejecuté la verificación de sintaxis XML de los archivos modificados con `python3` y `xml.etree.ElementTree.parse(...)`, y la comprobación devolvió `ok` para cada `*.xhtml` modificado. (éxito)
- Verifiqué reglas básicas con `git diff --check` para detectar conflictos de espacios y cambios aplicados, sin errores reportados. (éxito)
- Intenté compilar con `ant -q build`, pero la ejecución falló por la ausencia de `ant` en el entorno de ejecución. (fallido por entorno)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b42fd6fec83279644d9cc616074fc)