### PR TITLE
Permitir múltiples motivos DDHH

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -1004,6 +1004,60 @@ public class Expediente implements Serializable {
     public void setDdhhHerederosDetalle(String ddhhHerederosDetalle) { this.ddhhHerederosDetalle = ddhhHerederosDetalle; }
     public String[] getDdhhMotivos() { return convertirTextoAArray(ddhhMotivos); }
     public void setDdhhMotivos(String[] ddhhMotivos) { this.ddhhMotivos = convertirArrayATexto(ddhhMotivos); }
+    public String[] getDdhhMotivosPrincipales() {
+        java.util.List<String> motivosPrincipales = new java.util.ArrayList<String>();
+        for (String motivo : getDdhhMotivos()) {
+            if (esDdhhMotivoPrincipal(motivo)) {
+                motivosPrincipales.add(motivo);
+            }
+        }
+        return motivosPrincipales.toArray(new String[motivosPrincipales.size()]);
+    }
+
+    public void setDdhhMotivosPrincipales(String[] ddhhMotivosPrincipales) {
+        java.util.List<String> motivos = new java.util.ArrayList<String>();
+        if (ddhhMotivosPrincipales != null) {
+            for (String motivoPrincipal : ddhhMotivosPrincipales) {
+                if (motivoPrincipal != null && !motivoPrincipal.trim().isEmpty()) {
+                    motivos.add(motivoPrincipal);
+                }
+            }
+        }
+        for (String motivo : getDdhhMotivos()) {
+            if (motivo != null && !esDdhhMotivoPrincipal(motivo)) {
+                motivos.add(motivo);
+            }
+        }
+        setDdhhMotivos(motivos.toArray(new String[motivos.size()]));
+    }
+
+    public String[] getDdhhMotivosSecundarios() {
+        java.util.List<String> motivosSecundarios = new java.util.ArrayList<String>();
+        for (String motivo : getDdhhMotivos()) {
+            if (motivo != null && !esDdhhMotivoPrincipal(motivo)) {
+                motivosSecundarios.add(motivo);
+            }
+        }
+        return motivosSecundarios.toArray(new String[motivosSecundarios.size()]);
+    }
+
+    public void setDdhhMotivosSecundarios(String[] ddhhMotivosSecundarios) {
+        java.util.List<String> motivos = new java.util.ArrayList<String>();
+        for (String motivo : getDdhhMotivos()) {
+            if (esDdhhMotivoPrincipal(motivo)) {
+                motivos.add(motivo);
+            }
+        }
+        if (ddhhMotivosSecundarios != null) {
+            for (String motivoSecundario : ddhhMotivosSecundarios) {
+                if (motivoSecundario != null && !motivoSecundario.trim().isEmpty()) {
+                    motivos.add(motivoSecundario);
+                }
+            }
+        }
+        setDdhhMotivos(motivos.toArray(new String[motivos.size()]));
+    }
+
     public String getDdhhMotivoPrincipal() {
         for (String motivo : getDdhhMotivos()) {
             if (esDdhhMotivoPrincipal(motivo)) {

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -163,17 +163,17 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectOneRadio id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
+                                            <p:selectManyCheckbox id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
                                                 <p:ajax update="ddhhMotivosDetalle" />
-                                            </p:selectOneRadio>
+                                            </p:selectManyCheckbox>
                                             <h:panelGroup id="ddhhMotivosDetalle" layout="block">
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
                                                     <p:outputLabel value="Opciones inmueble:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />
@@ -184,7 +184,7 @@
                                                 </h:panelGroup>
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
                                                     <p:outputLabel value="Opciones automotor:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -122,17 +122,17 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectOneRadio id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
+                                            <p:selectManyCheckbox id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
                                                 <p:ajax update="ddhhMotivosDetalle" />
-                                            </p:selectOneRadio>
+                                            </p:selectManyCheckbox>
                                             <h:panelGroup id="ddhhMotivosDetalle" layout="block">
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
                                                     <p:outputLabel value="Opciones inmueble:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />
@@ -143,7 +143,7 @@
                                                 </h:panelGroup>
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
                                                     <p:outputLabel value="Opciones automotor:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -393,17 +393,17 @@
                                         </div>
                                         <div class="columna">
                                             <p:outputLabel value="Motivo DDHH:" />
-                                            <p:selectOneRadio id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
+                                            <p:selectManyCheckbox id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
                                                 <p:ajax update="ddhhMotivosDetalle" />
-                                            </p:selectOneRadio>
+                                            </p:selectManyCheckbox>
                                             <h:panelGroup id="ddhhMotivosDetalle" layout="block">
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
                                                     <p:outputLabel value="Opciones inmueble:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />
@@ -414,7 +414,7 @@
                                                 </h:panelGroup>
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
                                                     <p:outputLabel value="Opciones automotor:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />
@@ -988,7 +988,7 @@
 
                                         <f:selectItem itemLabel="Sí" itemValue="Si" />
                                         <f:selectItem itemLabel="No" itemValue="No" />
-                                    </p:selectOneRadio>
+                                    </p:selectManyCheckbox>
 
                                 </div>
                             </div>

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -404,17 +404,17 @@
                                         </div>
                             <div class="columna">
                                             <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" value="Motivo DDHH:" />
-                                            <p:selectOneRadio rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivoPrincipal}">
+                                            <p:selectManyCheckbox rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}" id="ddhhMotivos" layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosPrincipales}">
                                                 <f:selectItem itemLabel="Inmueble" itemValue="Inmueble" />
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
                                                 <p:ajax update="ddhhMotivosDetalle" />
-                                            </p:selectOneRadio>
+                                            </p:selectManyCheckbox>
                                             <h:panelGroup id="ddhhMotivosDetalle" layout="block" rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}">
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">
                                                     <p:outputLabel value="Opciones inmueble:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />
@@ -425,7 +425,7 @@
                                                 </h:panelGroup>
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoAutomotorSeleccionado}">
                                                     <p:outputLabel value="Opciones automotor:" />
-                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivos}">
+                                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selected.ddhhMotivosSecundarios}">
                                                         <f:selectItem itemLabel="Ganancial" itemValue="Ganancial" />
                                                         <f:selectItem itemLabel="Propio" itemValue="Propio" />
                                                         <f:selectItem itemLabel="Venta" itemValue="Venta" />
@@ -1156,7 +1156,7 @@
 
                                     <f:selectItem itemLabel="Sí" itemValue="Si" />
                                     <f:selectItem itemLabel="No" itemValue="No" />
-                                </p:selectOneRadio>
+                                </p:selectManyCheckbox>
 
                             </div>
                         </div>


### PR DESCRIPTION
### Motivation
- Los formularios DDHH permitían seleccionar un solo motivo principal (Inmueble/Automotor/Cobro de crédito/Otro) pero un mismo causante puede tener varios bienes, por lo que se requiere selección múltiple.

### Description
- Cambia el control principal de motivo DDHH de `p:selectOneRadio` a `p:selectManyCheckbox` en `web/expediente/Create.xhtml`, `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/Edit.xhtml` y `web/expediente/EditExpJudicial.xhtml` para permitir seleccionar varios motivos a la vez.
- Añade en el modelo `Expediente` (archivo `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java`) las propiedades y métodos `getDdhhMotivosPrincipales`/`setDdhhMotivosPrincipales` y `getDdhhMotivosSecundarios`/`setDdhhMotivosSecundarios` para separar lógica de motivos principales y secundarios manteniendo el almacenamiento existente en `ddhhMotivos`.
- Ajusta los checkboxes secundarios de opciones (Ganancial/Propio/Venta/Adjudicación) para usar `ddhhMotivosSecundarios` y evita que las opciones secundarias sobrescriban los motivos principales al persistir.
- Se preserva la compatibilidad con el campo almacenado `ddhhMotivos` y la lógica auxiliar existente como `esDdhhMotivoPrincipal`.

### Testing
- Ejecutado `git diff --check` sin errores detectados; la verificación de formato pasó correctamente.
- Intentado compilar con `ant -q compile` pero no se pudo ejecutar porque `ant` no está instalado en el entorno; por ello no se realizó una compilación completa automática en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c6df94dc0832799b865d94e88cb15)