### PR TITLE
Corregir cierre de `p:selectOneRadio` `poderFirmado` en vistas de expediente

### DIFF
--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -988,7 +988,7 @@
 
                                         <f:selectItem itemLabel="Sí" itemValue="Si" />
                                         <f:selectItem itemLabel="No" itemValue="No" />
-                                    </p:selectManyCheckbox>
+                                    </p:selectOneRadio>
 
                                 </div>
                             </div>

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -1156,7 +1156,7 @@
 
                                     <f:selectItem itemLabel="Sí" itemValue="Si" />
                                     <f:selectItem itemLabel="No" itemValue="No" />
-                                </p:selectManyCheckbox>
+                                </p:selectOneRadio>
 
                             </div>
                         </div>


### PR DESCRIPTION
### Motivation
- Se detectó un cierre de etiqueta incorrecto que provocaba un error de parseo en las vistas JSF y podía romper el componente radio `poderFirmado` en la edición de expedientes.

### Description
- Reemplacé el cierre erróneo `</p:selectManyCheckbox>` por `</p:selectOneRadio>` para el componente `poderFirmado` en `web/expediente/Edit.xhtml` y `web/expediente/EditExpJudicial.xhtml`.

### Testing
- Validé que ambos archivos son parseables con `python - <<'PY' ... ET.parse(...)` y la comprobación devolvió `OK` para `web/expediente/Edit.xhtml` y `web/expediente/EditExpJudicial.xhtml`.
- Ejecuté `git diff --check` para detectar problemas de sintaxis/whitespace y no reportó errores.
- Intenté ejecutar `xmllint --noout web/expediente/Edit.xhtml web/expediente/EditExpJudicial.xhtml`, pero `xmllint` no está instalado en el entorno y la comprobación no pudo realizarse.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d167b2d8483278108d4a844ac832e)