### PR TITLE
Evitar sobrescritura concurrente de expedientes

### DIFF
--- a/ALTER_TABLE_EXPEDIENTE_ADD_VERSION.sql
+++ b/ALTER_TABLE_EXPEDIENTE_ADD_VERSION.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Expediente
+    ADD COLUMN version INT NOT NULL DEFAULT 0;

--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -14,6 +14,7 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Version;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -57,6 +58,10 @@ public class Expediente implements Serializable {
     @Basic(optional = false)
     @Column(name = "idExpediente")
     private Integer idExpediente;
+
+    @Version
+    @Column(name = "version")
+    private Integer version;
     
     @Basic(optional = false)
     @Column(name = "orden")
@@ -462,6 +467,14 @@ public class Expediente implements Serializable {
 
     public void setIdExpediente(Integer idExpediente) {
         this.idExpediente = idExpediente;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
     }
 
     public Integer getOrden() {

--- a/src/java/com/estudioAlvarezVersion2/jpacontroller/ExpedienteFacade.java
+++ b/src/java/com/estudioAlvarezVersion2/jpacontroller/ExpedienteFacade.java
@@ -28,6 +28,13 @@ public class ExpedienteFacade extends AbstractFacade<Expediente> {
     public ExpedienteFacade() {
         super(Expediente.class);
     }
+
+    public Expediente editAndRefresh(Expediente expediente) {
+        Expediente managedExpediente = em.merge(expediente);
+        em.flush();
+        em.refresh(managedExpediente);
+        return managedExpediente;
+    }
     
     public String findClaveCidiByOrden(int orden) {
         try {

--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -51,6 +51,7 @@ import java.util.Comparator;
 import java.util.concurrent.TimeUnit;
 import javax.faces.view.ViewScoped;
 import javax.persistence.EntityManager;
+import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceContext;
 import javax.servlet.http.HttpSession;
 import org.primefaces.context.RequestContext;
@@ -758,6 +759,10 @@ public class ExpedienteController implements Serializable {
                 }
                 JsfUtil.addSuccessMessage(successMessage);
             } catch (EJBException ex) {
+                if (isOptimisticLockException(ex)) {
+                    handleConcurrentExpedienteUpdate();
+                    return;
+                }
                 String msg = "";
                 Throwable cause = ex.getCause();
                 if (cause != null) {
@@ -769,10 +774,39 @@ public class ExpedienteController implements Serializable {
                     JsfUtil.addErrorMessage(ex, ResourceBundle.getBundle("/Bundle").getString("PersistenceErrorOccured"));
                 }
             } catch (Exception ex) {
+                if (isOptimisticLockException(ex)) {
+                    handleConcurrentExpedienteUpdate();
+                    return;
+                }
                 Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, null, ex);
                 JsfUtil.addErrorMessage(ex, ResourceBundle.getBundle("/Bundle").getString("PersistenceErrorOccured"));
             }
         }
+    }
+
+    private boolean isOptimisticLockException(Throwable ex) {
+        Throwable cause = ex;
+
+        while (cause != null) {
+            if (cause instanceof OptimisticLockException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+
+        return false;
+    }
+
+    private void handleConcurrentExpedienteUpdate() {
+        Integer idExpediente = selected != null ? selected.getIdExpediente() : null;
+
+        if (idExpediente != null) {
+            selected = getFacade().find(idExpediente);
+        }
+
+        items = null;
+        activeItems = null;
+        JsfUtil.addErrorMessage("No se guardaron los cambios porque este expediente fue modificado por otro usuario. Se volvió a cargar la última versión; revise los datos y vuelva a guardar si corresponde.");
     }
 
     public Expediente getExpediente(java.lang.Integer id) {

--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -753,10 +753,11 @@ public class ExpedienteController implements Serializable {
             setEmbeddableKeys();
             try {
                 if (persistAction != PersistAction.DELETE) {
-                    getFacade().edit(selected);
+                    selected = getFacade().editAndRefresh(selected);
                 } else {
                     getFacade().remove(selected);
                 }
+                invalidateExpedienteCaches();
                 JsfUtil.addSuccessMessage(successMessage);
             } catch (EJBException ex) {
                 if (isOptimisticLockException(ex)) {
@@ -804,9 +805,14 @@ public class ExpedienteController implements Serializable {
             selected = getFacade().find(idExpediente);
         }
 
+        invalidateExpedienteCaches();
+        JsfUtil.addErrorMessage("No se guardaron los cambios porque este expediente fue modificado por otro usuario. Se volvió a cargar la última versión; revise los datos y vuelva a guardar si corresponde.");
+    }
+
+    private void invalidateExpedienteCaches() {
         items = null;
         activeItems = null;
-        JsfUtil.addErrorMessage("No se guardaron los cambios porque este expediente fue modificado por otro usuario. Se volvió a cargar la última versión; revise los datos y vuelva a guardar si corresponde.");
+        filteredExpedientes = null;
     }
 
     public Expediente getExpediente(java.lang.Integer id) {


### PR DESCRIPTION
### Motivation
- Evitar que un usuario sobrescriba cambios hechos por otro usuario cuando ambos editan el mismo `Expediente` en sesiones diferentes mediante detección de ediciones concurrentes.
- Implementar un mecanismo simple de bloqueo optimista para que JPA detecte conflictos y el controlador recargue la última versión en caso de conflicto.

### Description
- Se agregó un campo de versionado optimista `@Version` `version` en la entidad `Expediente` junto con sus `getVersion()` y `setVersion()` accesores (archivo `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java`).
- Se añadió el script SQL `ALTER_TABLE_EXPEDIENTE_ADD_VERSION.sql` que agrega la columna `version` a la tabla `Expediente` con `DEFAULT 0` para preparar la base de datos.
- Se actualizó `ExpedienteController.persist(...)` para detectar `OptimisticLockException` y manejarlo sin pisar datos, añadiendo los métodos auxiliares `isOptimisticLockException(...)` y `handleConcurrentExpedienteUpdate()` y la importación de `OptimisticLockException` (archivo `src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java`).
- En caso de conflicto la lógica recarga la última entidad desde la base (`getFacade().find(id)`), invalida las listas en memoria (`items` y `activeItems`) y muestra un mensaje claro al usuario para que revise y reintente guardar.

### Testing
- Se intentó compilar con `ant -q compile` para validar la compilación, pero la ejecución falló porque `ant` no está instalado en el entorno, por lo que la compilación automática no se pudo verificar aquí.
- No se ejecutaron pruebas unitarias o de integración automáticas en este entorno, por lo que se recomienda ejecutar la compilación y pruebas en CI y aplicar el script SQL en la base antes de desplegar en producción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de25f18a48327b923dd8578aefbab)