### PR TITLE
Mostrar JP Tipo solo para expedientes de Justicia Provincial

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -291,6 +291,10 @@ public class ExpedienteController implements Serializable {
         return isExpedienteJudicialDdhhJusticiaProvincial(selected);
     }
 
+    public boolean isExpedienteSeleccionadoJusticiaProvincial() {
+        return selected != null && equalsIgnoreCaseTrim(selected.getEquipo(), JUSTICIA_PROVINCIAL);
+    }
+
     private boolean isExpedienteJudicialDdhhJusticiaProvincial(Expediente expediente) {
         if (expediente == null) {
             return false;

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -362,8 +362,8 @@
                                         <f:selectItem itemLabel=" -- Elige un típo de trámite --"  noSelectionOption="true"  />
                                         <f:selectItems value="#{tipoDeTramiteController.items}" var="tipoDeTramite" itemLabel="#{tipoDeTramite.estado}" itemValue="#{tipoDeTramite.estado}" />
                                     </p:selectOneMenu>
-                                    <p:outputLabel value="JP Tipo:" for="jpTipo" style="font-weight: bold" />
-                                    <p:selectOneMenu id="jpTipo" value="#{expedienteController.selected.jpTipo}" editable="true">
+                                    <p:outputLabel value="JP Tipo:" for="jpTipo" style="font-weight: bold" rendered="#{expedienteController.expedienteSeleccionadoJusticiaProvincial}" />
+                                    <p:selectOneMenu id="jpTipo" value="#{expedienteController.selected.jpTipo}" editable="true" rendered="#{expedienteController.expedienteSeleccionadoJusticiaProvincial}">
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
@@ -372,7 +372,7 @@
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="ddhhPanel" />
                                     </p:selectOneMenu>
-                                    <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                    <h:panelGroup id="ddhhPanel" layout="block" rendered="#{expedienteController.expedienteSeleccionadoJusticiaProvincial}" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">
                                             <p:outputLabel value="Causante:" for="ddhhCausante" />
                                             <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />


### PR DESCRIPTION
### Motivation
- Evitar que el campo "JP Tipo" y su panel asociado DDHH se muestren para expedientes que no pertenecen al equipo JUSTICIA PROVINCIAL.

### Description
- Agrega el helper `isExpedienteSeleccionadoJusticiaProvincial()` en `ExpedienteController.java` para comprobar si el `selected` pertenece a `JUSTICIA PROVINCIAL`.
- Condiciona en `web/expediente/Edit.xhtml` la renderización del `p:outputLabel` y del `p:selectOneMenu` con id `jpTipo` usando `#{expedienteController.expedienteSeleccionadoJusticiaProvincial}`.
- También añade la misma condición de renderizado al `h:panelGroup` con id `ddhhPanel` para que no se muestre fuera de Justicia Provincial.

### Testing
- Ejecuté `git diff --check` como verificación estática y no reportó errores (pasó).
- Intenté ejecutar `ant -p` pero no se pudo completar porque `ant` no está instalado en el entorno (falló por falta de herramienta).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4354d2d4248327bb5ce6f3f9748762)