### PR TITLE
Confirmación al cambiar expediente de Administrativo a Judicial

### DIFF
--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -21,6 +21,16 @@
                 document.getElementById("myDialog").showModal();
             }
 
+            function confirmarCambioAdministrativoAJudicial(select) {
+                if (select.value === 'judicial'
+                        && !confirm('Está por cambiar la instancia de Administrativo a Judicial. Esta acción es irreversible. ¿Desea continuar?')) {
+                    select.value = 'administrativo';
+                    return false;
+                }
+
+                return true;
+            }
+
             function prepararDescargaReporteFinal(formId) {
                 var form = document.getElementById(formId);
                 if (!form) {
@@ -349,7 +359,7 @@
                             <div class="datosexpediente">
                                 <div class="columna">
                                     <p:outputLabel value="Tipo de Expediente"  for="tipoDeExpediente"  class="float-l"/>
-                                    <p:selectOneMenu id="tipoDeExpediente"  value="#{expedienteController.selected.tipoDeExpediente}" editable="false" >
+                                    <p:selectOneMenu id="tipoDeExpediente"  value="#{expedienteController.selected.tipoDeExpediente}" editable="false" onchange="return confirmarCambioAdministrativoAJudicial(this);" >
                                         <f:selectItem class="subMenu" itemLabel="Administrativo" itemValue="administrativo" />
                                         <f:selectItem class="subMenu" itemLabel="Judicial" itemValue="judicial" />
                                     </p:selectOneMenu>


### PR DESCRIPTION
### Motivation
- Evitar cambios irreversibles accidentales al convertir un expediente de `administrativo` a `judicial` mostrando una confirmación explícita antes de efectuar el cambio.

### Description
- Se añadió la función JavaScript `confirmarCambioAdministrativoAJudicial` en `web/expediente/Edit.xhtml` y se asoció al `p:selectOneMenu` de `tipoDeExpediente` mediante `onchange`, de modo que al seleccionar `judicial` se muestra un `confirm` y, si el usuario cancela, la selección se revierte a `administrativo`.

### Testing
- Ejecutado `xmllint --noout web/expediente/Edit.xhtml`, pero la herramienta no está disponible en el entorno y la comprobación no pudo realizarse. 
- Ejecutado `ant -q -Dbuild.compiler=modern compile`, pero `ant` no está instalado en el entorno y la compilación automatizada no pudo realizarse.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4355b000408327bb2b512aabf0bea5)