### PR TITLE
Fix Facelets parsing by escaping '&&' in web/expediente/Edit.xhtml

### DIFF
--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -23,7 +23,7 @@
 
             function confirmarCambioAdministrativoAJudicial(select) {
                 if (select.value === 'judicial'
-                        && !confirm('Está por cambiar la instancia de Administrativo a Judicial. Esta acción es irreversible. ¿Desea continuar?')) {
+                        &amp;&amp; !confirm('Está por cambiar la instancia de Administrativo a Judicial. Esta acción es irreversible. ¿Desea continuar?')) {
                     select.value = 'administrativo';
                     return false;
                 }


### PR DESCRIPTION
### Motivation
- The Facelets/XHTML parser failed with "The entity name must immediately follow the '&'" due to an unescaped JavaScript logical AND (`&&`) inside `web/expediente/Edit.xhtml` which made the parser treat `&` as an invalid entity reference.

### Description
- Replace the raw `&&` with the escaped entity `&amp;&amp;` in `web/expediente/Edit.xhtml` so the JavaScript remains correct while the XHTML/Facelets parser accepts the file.

### Testing
- Ran a quick XML parse check with `python3` (`ET.parse('web/expediente/Edit.xhtml')`) which succeeded; running `ant -q test` was attempted but not executed because `ant` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4361852e2c8327b7492f23a1376cd4)