### PR TITLE
Actualizar listado genérico de jurisdicciones

### DIFF
--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -197,13 +197,22 @@
                             <h:panelGrid columns="4" cellspacing="5" style="margin-top: 3%">
                                 <p:outputLabel value="Jurisdicción:" for="jurisdiccion" style="font-weight: bold" />
                                 <p:selectOneMenu id="jurisdiccion" style="margin-left: 3%" value="#{expedienteController.selected.jurisdiccion}" editable="true" >
-                                    <f:selectItem itemLabel="Provincia - Juzgado N°" itemValue="Provincia - Juzgado N°" />
-                                    <f:selectItem itemLabel="Provincia - Cámara" itemValue="Provincia - Cámara" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 1" itemValue="Federales - Juzgado 1" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 2" itemValue="Federales - Juzgado 2" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 3" itemValue="Federales - Juzgado 3" />
-                                    <f:selectItem itemLabel="Federales - Camara - Sala A" itemValue="Federales - Camara - Sala A" />
-                                    <f:selectItem itemLabel="Federales - Camara - Sala B" itemValue="Federales - Camara - Sala B" />
+                                    <f:selectItem itemLabel="LABORAL – TGA N°" itemValue="LABORAL – TGA N°" />
+                                    <f:selectItem itemLabel="LABORAL – JUZG. CONC. N°" itemValue="LABORAL – JUZG. CONC. N°" />
+                                    <f:selectItem itemLabel="LABORAL – CÁMARA N°" itemValue="LABORAL – CÁMARA N°" />
+                                    <f:selectItem itemLabel="LABORAL – TSJ" itemValue="LABORAL – TSJ" />
+                                    <f:selectItem itemLabel="CIVIL – OPS" itemValue="CIVIL – OPS" />
+                                    <f:selectItem itemLabel="CIVIL – JUZG. N°" itemValue="CIVIL – JUZG. N°" />
+                                    <f:selectItem itemLabel="CIVIL – CÁMARA AP." itemValue="CIVIL – CÁMARA AP." />
+                                    <f:selectItem itemLabel="CIVIL – TSJ" itemValue="CIVIL – TSJ" />
+                                    <f:selectItem itemLabel="CONT. ADM. – CÁMARA N°" itemValue="CONT. ADM. – CÁMARA N°" />
+                                    <f:selectItem itemLabel="CONT. ADM. – TSJ" itemValue="CONT. ADM. – TSJ" />
+                                    <f:selectItem itemLabel="FAMILIA – JUZGADO N°" itemValue="FAMILIA – JUZGADO N°" />
+                                    <f:selectItem itemLabel="FAMILIA – CÁMARA N°" itemValue="FAMILIA – CÁMARA N°" />
+                                    <f:selectItem itemLabel="LABORAL INTERIOR – JUZG. N°" itemValue="LABORAL INTERIOR – JUZG. N°" />
+                                    <f:selectItem itemLabel="LABORAL INTERIOR – CÁMARA N°" itemValue="LABORAL INTERIOR – CÁMARA N°" />
+                                    <f:selectItem itemLabel="CIVIL INTERIOR – JUZG. N°" itemValue="CIVIL INTERIOR – JUZG. N°" />
+                                    <f:selectItem itemLabel="CIVIL INTERIOR – CÁMARA N°" itemValue="CIVIL INTERIOR – CÁMARA N°" />
                                 </p:selectOneMenu>
 
                                 <p:outputLabel value="Etapa Procesal:" for="etapaProcesal" style="margin-left: 6%;font-weight: bold" />

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -536,13 +536,22 @@
                                                value="Jurisdicción:" for="jurisdiccion"  />
                                 <p:selectOneMenu rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}"
                                                  id="jurisdiccion"  value="#{expedienteController.selected.jurisdiccion}" editable="true" >
-                                    <f:selectItem itemLabel="Provincia - Juzgado N°" itemValue="Provincia - Juzgado N°" />
-                                    <f:selectItem itemLabel="Provincia - Cámara" itemValue="Provincia - Cámara" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 1" itemValue="Federales - Juzgado 1" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 2" itemValue="Federales - Juzgado 2" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 3" itemValue="Federales - Juzgado 3" />
-                                    <f:selectItem itemLabel="Federales - Camara - Sala A" itemValue="Federales - Camara - Sala A" />
-                                    <f:selectItem itemLabel="Federales - Camara - Sala B" itemValue="Federales - Camara - Sala B" />
+                                    <f:selectItem itemLabel="LABORAL – TGA N°" itemValue="LABORAL – TGA N°" />
+                                    <f:selectItem itemLabel="LABORAL – JUZG. CONC. N°" itemValue="LABORAL – JUZG. CONC. N°" />
+                                    <f:selectItem itemLabel="LABORAL – CÁMARA N°" itemValue="LABORAL – CÁMARA N°" />
+                                    <f:selectItem itemLabel="LABORAL – TSJ" itemValue="LABORAL – TSJ" />
+                                    <f:selectItem itemLabel="CIVIL – OPS" itemValue="CIVIL – OPS" />
+                                    <f:selectItem itemLabel="CIVIL – JUZG. N°" itemValue="CIVIL – JUZG. N°" />
+                                    <f:selectItem itemLabel="CIVIL – CÁMARA AP." itemValue="CIVIL – CÁMARA AP." />
+                                    <f:selectItem itemLabel="CIVIL – TSJ" itemValue="CIVIL – TSJ" />
+                                    <f:selectItem itemLabel="CONT. ADM. – CÁMARA N°" itemValue="CONT. ADM. – CÁMARA N°" />
+                                    <f:selectItem itemLabel="CONT. ADM. – TSJ" itemValue="CONT. ADM. – TSJ" />
+                                    <f:selectItem itemLabel="FAMILIA – JUZGADO N°" itemValue="FAMILIA – JUZGADO N°" />
+                                    <f:selectItem itemLabel="FAMILIA – CÁMARA N°" itemValue="FAMILIA – CÁMARA N°" />
+                                    <f:selectItem itemLabel="LABORAL INTERIOR – JUZG. N°" itemValue="LABORAL INTERIOR – JUZG. N°" />
+                                    <f:selectItem itemLabel="LABORAL INTERIOR – CÁMARA N°" itemValue="LABORAL INTERIOR – CÁMARA N°" />
+                                    <f:selectItem itemLabel="CIVIL INTERIOR – JUZG. N°" itemValue="CIVIL INTERIOR – JUZG. N°" />
+                                    <f:selectItem itemLabel="CIVIL INTERIOR – CÁMARA N°" itemValue="CIVIL INTERIOR – CÁMARA N°" />
                                 </p:selectOneMenu>
 
                                 <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}"

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -434,13 +434,22 @@
 
                                 <p:outputLabel value="Jurisdicción:" for="jurisdiccion"  />
                                 <p:selectOneMenu id="jurisdiccion"  value="#{expedienteController.selectedParaVerExp.jurisdiccion}" editable="true" >
-                                    <f:selectItem itemLabel="Provincia - Juzgado N°" itemValue="Provincia - Juzgado N°" />
-                                    <f:selectItem itemLabel="Provincia - Cámara" itemValue="Provincia - Cámara" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 1" itemValue="Federales - Juzgado 1" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 2" itemValue="Federales - Juzgado 2" />
-                                    <f:selectItem itemLabel="Federales - Juzgado 3" itemValue="Federales - Juzgado 3" />
-                                    <f:selectItem itemLabel="Federales - Camara - Sala A" itemValue="Federales - Camara - Sala A" />
-                                    <f:selectItem itemLabel="Federales - Camara - Sala B" itemValue="Federales - Camara - Sala B" />
+                                    <f:selectItem itemLabel="LABORAL – TGA N°" itemValue="LABORAL – TGA N°" />
+                                    <f:selectItem itemLabel="LABORAL – JUZG. CONC. N°" itemValue="LABORAL – JUZG. CONC. N°" />
+                                    <f:selectItem itemLabel="LABORAL – CÁMARA N°" itemValue="LABORAL – CÁMARA N°" />
+                                    <f:selectItem itemLabel="LABORAL – TSJ" itemValue="LABORAL – TSJ" />
+                                    <f:selectItem itemLabel="CIVIL – OPS" itemValue="CIVIL – OPS" />
+                                    <f:selectItem itemLabel="CIVIL – JUZG. N°" itemValue="CIVIL – JUZG. N°" />
+                                    <f:selectItem itemLabel="CIVIL – CÁMARA AP." itemValue="CIVIL – CÁMARA AP." />
+                                    <f:selectItem itemLabel="CIVIL – TSJ" itemValue="CIVIL – TSJ" />
+                                    <f:selectItem itemLabel="CONT. ADM. – CÁMARA N°" itemValue="CONT. ADM. – CÁMARA N°" />
+                                    <f:selectItem itemLabel="CONT. ADM. – TSJ" itemValue="CONT. ADM. – TSJ" />
+                                    <f:selectItem itemLabel="FAMILIA – JUZGADO N°" itemValue="FAMILIA – JUZGADO N°" />
+                                    <f:selectItem itemLabel="FAMILIA – CÁMARA N°" itemValue="FAMILIA – CÁMARA N°" />
+                                    <f:selectItem itemLabel="LABORAL INTERIOR – JUZG. N°" itemValue="LABORAL INTERIOR – JUZG. N°" />
+                                    <f:selectItem itemLabel="LABORAL INTERIOR – CÁMARA N°" itemValue="LABORAL INTERIOR – CÁMARA N°" />
+                                    <f:selectItem itemLabel="CIVIL INTERIOR – JUZG. N°" itemValue="CIVIL INTERIOR – JUZG. N°" />
+                                    <f:selectItem itemLabel="CIVIL INTERIOR – CÁMARA N°" itemValue="CIVIL INTERIOR – CÁMARA N°" />
                                 </p:selectOneMenu>
 
                                 <p:outputLabel value="Etapa Procesal:" for="etapaProcesal" />


### PR DESCRIPTION
### Motivation
- Cambiar el campo "Jurisdicción" para usar un conjunto de jurisdicciones genéricas en lugar de un listado de juzgados específicos para simplificar el mantenimiento y permitir que el usuario complete manualmente el número o denominación del tribunal. 
- Evitar la carga y actualización de cada tribunal individual y dar mayor flexibilidad al registrar el órgano jurisdiccional.

### Description
- Reemplacé la lista previa de opciones por las 16 jurisdicciones genéricas solicitadas en `web/expediente/CreateExpJudicial.xhtml`. 
- Apliqué la misma lista de opciones en `web/expediente/EditExpJudicial.xhtml` y en `web/expediente/viewEnAgenda/EditExpJudicial.xhtml`. 
- Conservé `editable="true"` en los `p:selectOneMenu` afectados para que el usuario pueda seleccionar la jurisdicción base y completar el número o identificación específica del tribunal manualmente.

### Testing
- Ejecuté `rg -n "Provincia - Juzgado|Federales -|Provincia - Cámara|Federales - Camara" web/expediente src || true` y no se encontraron coincidencias con las opciones antiguas, indicando que la sustitución se aplicó correctamente. 
- Ejecuté `git diff --check` y no se informaron problemas de formato en las modificaciones. 
- Intenté `ant -q -f build.xml compile` pero no se ejecutó porque `ant` no está instalado en el entorno de ejecución.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4369adac10832780bdce59b0368330)