### PR TITLE
Corrige visualización DDHH para expedientes judiciales

### DIFF
--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -382,7 +382,8 @@
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="ddhhPanel" />
                                     </p:selectOneMenu>
-                                    <h:panelGroup id="ddhhPanel" layout="block" rendered="#{expedienteController.expedienteSeleccionadoJusticiaProvincial}" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                    <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                    <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}">
                                         <div class="columna">
                                             <p:outputLabel value="Causante:" for="ddhhCausante" />
                                             <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
@@ -449,6 +450,7 @@
                                             <p:outputLabel value="Observaciones DDHH:" for="ddhhObservaciones" />
                                             <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
                                         </div>
+                                    </h:panelGroup>
                                     </h:panelGroup>
 
 

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -376,7 +376,8 @@
                                 <p:ajax update="ddhhPanel" />
                                 </p:selectOneMenu>
 
-                                <h:panelGroup id="ddhhPanel" layout="block" rendered="#{expedienteController.expedienteSeleccionadoJusticiaProvincial}" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
+                                <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                    <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}">
                                     <p:outputLabel value="Causante:" for="ddhhCausante" />
                                     <p:inputText id="ddhhCausante" value="#{expedienteController.selected.ddhhCausante}" />
                                     <p:outputLabel value="DNI:" for="ddhhDni" />
@@ -439,6 +440,7 @@
                                     <p:inputText id="ddhhMadreCausante" value="#{expedienteController.selected.ddhhMadreCausante}" />
                                     <p:outputLabel value="Observaciones DDHH:" for="ddhhObservaciones" />
                                     <p:inputTextarea id="ddhhObservaciones" value="#{expedienteController.selected.ddhhObservaciones}" rows="4" cols="30" autoResize="false" />
+                                    </h:panelGroup>
                                 </h:panelGroup>
 
                                 <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">


### PR DESCRIPTION
### Motivation
- Evitar que la sección de datos `DDHH` se muestre en pantallas incorrectas cuando `jpTipo` quede en `DDHH` pero el expediente no sea judicial o no pertenezca a `JUSTICIA PROVINCIAL`.
- La condición anterior dependía del estilo `display` y de `expedienteSeleccionadoJusticiaProvincial`, lo que permitía que la UI quedara visible en casos no deseados; se requiere la comprobación completa (tipo judicial + `JP Tipo = DDHH` + equipo `JUSTICIA PROVINCIAL`).

### Description
- Modifica `web/expediente/EditExpJudicial.xhtml` y `web/expediente/Edit.xhtml` para mantener el contenedor `ddhhPanel` actualizable por AJAX y mover la condición de renderizado a un `h:panelGroup` interno que usa `#{expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}`.
- Ajusta la estructura de etiquetas (anida un `h:panelGroup` renderizado dentro del `ddhhPanel`) para que la visibilidad real de los campos DDHH dependa de la comprobación completa implementada en el controlador.
- Mensaje de commit: `Corrige visualización DDHH para expedientes judiciales`.

### Testing
- Parseo XML de los archivos modificados con `python3` y `xml.etree.ElementTree`: `ET.parse(...)` sobre `web/expediente/EditExpJudicial.xhtml` y `web/expediente/Edit.xhtml` — resultado: OK.
- Revisión de cambios con `git diff --check` — resultado: OK (sin warnings de índices mezclados).
- Intento de compilación `ant -q compile` falló por falta de `ant` en el entorno — resultado: no ejecutado.
- `xmllint` no disponible en el entorno, por lo que no se ejecutó la validación con esa herramienta.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46fbb1ec0c8327b6689fc907cc9bd1)