### PR TITLE
Preservar opciones DDHH al cambiar motivos

### DIFF
--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -168,7 +168,7 @@
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                                <p:ajax update="ddhhMotivosDetalle" />
+                                                <p:ajax process="@this ddhhMotivosDetalle" update="ddhhMotivosDetalle" />
                                             </p:selectManyCheckbox>
                                             <h:panelGroup id="ddhhMotivosDetalle" layout="block">
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -127,7 +127,7 @@
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                                <p:ajax update="ddhhMotivosDetalle" />
+                                                <p:ajax process="@this ddhhMotivosDetalle" update="ddhhMotivosDetalle" />
                                             </p:selectManyCheckbox>
                                             <h:panelGroup id="ddhhMotivosDetalle" layout="block">
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -409,7 +409,7 @@
                                                 <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                                 <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                                 <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                                <p:ajax update="ddhhMotivosDetalle" />
+                                                <p:ajax process="@this ddhhMotivosDetalle" update="ddhhMotivosDetalle" />
                                             </p:selectManyCheckbox>
                                             <h:panelGroup id="ddhhMotivosDetalle" layout="block">
                                                 <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -400,7 +400,7 @@
                                         <f:selectItem itemLabel="Automotor" itemValue="Automotor" />
                                         <f:selectItem itemLabel="Cobro de crédito" itemValue="Cobro de crédito" />
                                         <f:selectItem itemLabel="Otro" itemValue="Otro" />
-                                        <p:ajax update="ddhhMotivosDetalle" />
+                                        <p:ajax process="@this ddhhMotivosDetalle" update="ddhhMotivosDetalle" />
                                     </p:selectManyCheckbox>
                                     <h:panelGroup id="ddhhMotivosDetalle" layout="block">
                                         <h:panelGroup layout="block" rendered="#{expedienteController.selected.ddhhMotivoInmuebleSeleccionado}">


### PR DESCRIPTION
### Motivation
- Evitar que al alternar motivos DDHH (por ejemplo seleccionar primero `Inmueble` con sus opciones y luego `Automotor` o `Cobro de crédito`) se borren las selecciones ya marcadas en el panel de detalles al re-renderizarlo.

### Description
- En los archivos `web/expediente/Create.xhtml`, `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/Edit.xhtml` y `web/expediente/EditExpJudicial.xhtml` se reemplazó la llamada Ajax que solo actualizaba el panel por ` <p:ajax process="@this ddhhMotivosDetalle" update="ddhhMotivosDetalle" />` para procesar también el contenido del panel antes de redibujarlo.

### Testing
- Ejecuté `git diff --check` y no reportó errores.
- Intenté `ant -q compile` pero no se pudo ejecutar porque `ant` no está instalado en el entorno, por lo que la compilación automática no se realizó.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d119be40883278ad7f7433792d2bc)