### PR TITLE
Limitar campo 'Usuario SAC' solo a expedientes judiciales de Justicia Provincial

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -295,6 +295,19 @@ public class ExpedienteController implements Serializable {
         return selected != null && equalsIgnoreCaseTrim(selected.getEquipo(), JUSTICIA_PROVINCIAL);
     }
 
+    public boolean isExpedienteSeleccionadoJudicialJusticiaProvincial() {
+        return isExpedienteJudicialJusticiaProvincial(selected);
+    }
+
+    private boolean isExpedienteJudicialJusticiaProvincial(Expediente expediente) {
+        if (expediente == null) {
+            return false;
+        }
+
+        return equalsIgnoreCaseTrim(expediente.getTipoDeExpediente(), JUDICIAL)
+                && equalsIgnoreCaseTrim(expediente.getEquipo(), JUSTICIA_PROVINCIAL);
+    }
+
     private boolean isExpedienteJudicialDdhhJusticiaProvincial(Expediente expediente) {
         if (expediente == null) {
             return false;
@@ -303,6 +316,12 @@ public class ExpedienteController implements Serializable {
         return equalsIgnoreCaseTrim(expediente.getTipoDeExpediente(), JUDICIAL)
                 && equalsIgnoreCaseTrim(expediente.getJpTipo(), DDHH)
                 && equalsIgnoreCaseTrim(expediente.getEquipo(), JUSTICIA_PROVINCIAL);
+    }
+
+    private void limpiarUsuarioSacSiNoCorresponde() {
+        if (selected != null && !isExpedienteJudicialJusticiaProvincial(selected)) {
+            selected.setUsuarioSac(null);
+        }
     }
 
     private boolean equalsIgnoreCaseTrim(String value, String expected) {
@@ -476,6 +495,7 @@ public class ExpedienteController implements Serializable {
 
     public void create() {
 
+        limpiarUsuarioSacSiNoCorresponde();
         ingresarEdad();
 
         ingresarDni();
@@ -575,6 +595,8 @@ public class ExpedienteController implements Serializable {
         selected.setEdad(Math.toIntExact(years));
 
         selected.setDni(extractDniFromCuit(selected.getCuit()));
+
+        limpiarUsuarioSacSiNoCorresponde();
 
         String successMessage = "Expediente actualizado exitosamente";
 

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -261,8 +261,8 @@
                                         <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                     </p:selectOneMenu>
 
-                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac"/>
-                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
+                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
+                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                         <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
                                         <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                     </p:selectOneMenu>

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -179,6 +179,7 @@
                                          <p:selectOneMenu style="margin-left: 1%; margin-right: 1%" id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                             <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                             <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
+                                            <p:ajax update="usuarioSacPanel" />
                                         
                                          </p:selectOneMenu>
 
@@ -235,11 +236,13 @@
                                     <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                 </p:selectOneMenu>
 
-                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac"/>
-                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
-                                        <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
-                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
-                                    </p:selectOneMenu>
+                                    <h:panelGroup id="usuarioSacPanel">
+                                        <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
+                                        <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
+                                            <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
+                                            <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
                             <br></br><br></br>
                                 <p:outputLabel value="Expediente físico:" for="fisico" style="font-weight: bold"/>
                                 <p:selectOneMenu id="fisico" value="#{expedienteController.selected.fisico}">

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -493,8 +493,8 @@
                                         <f:selectItem itemLabel="María Paz Bolinaga" itemValue="María Paz Bolinaga" />
                                     </p:selectOneMenu>
 
-                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac"/>
-                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
+                                    <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
+                                    <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                         <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
                                         <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
                                     </p:selectOneMenu>

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -566,9 +566,9 @@
                                                    itemValue="#{empleado.nombreyApellido}" />
                                 </p:selectOneMenu>
 
-                                <p:outputLabel rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}"
+                                <p:outputLabel rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"
                                                value="Usuario SAC:" for="usuarioSac" />
-                                <p:selectOneMenu rendered="#{expedienteController.isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial()}"
+                                <p:selectOneMenu rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"
                                                  id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
                                     <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
                                     <f:selectItems value="#{empleadoController.items}" var="empleado"


### PR DESCRIPTION
### Motivation
- El campo `Usuario SAC` se estaba mostrando y guardando en expedientes de otros equipos/tipos (por ejemplo PREVISIONAL ADMINISTRATIVO) cuando debe aplicarse únicamente a expedientes **judiciales** del equipo **JUSTICIA PROVINCIAL**. 
- Se requiere una validación central y cambios en la UI para prevenir que valores de `usuarioSac` queden persistidos en expedientes no aplicables.

### Description
- Se agregó el método público `isExpedienteSeleccionadoJudicialJusticiaProvincial()` y el helper privado `isExpedienteJudicialJusticiaProvincial(Expediente)` en `src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java` para detectar expedientes judiciales de `JUSTICIA PROVINCIAL`.
- Se añadió `limpiarUsuarioSacSiNoCorresponde()` en `ExpedienteController` y se invoca desde `create()` y `update()` para dejar `usuarioSac` a `null` cuando el expediente no cumple la condición, evitando persistir valores indebidos.
- Se modificaron las vistas JSF para que el label y el `p:selectOneMenu` de `usuarioSac` se rendericen únicamente cuando corresponde: `web/expediente/Create.xhtml`, `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/Edit.xhtml` y `web/expediente/EditExpJudicial.xhtml`.
- En `CreateExpJudicial.xhtml` se añadió un `p:ajax update="usuarioSacPanel"` en el selector de `equipo` para refrescar dinámicamente la visibilidad del bloque `usuarioSac` al cambiar el equipo.

### Testing
- Ejecuté la verificación estática `git diff --check`, que no reportó problemas.
- Intenté compilar con `ant -q compile`, pero la compilación no pudo ejecutarse porque `ant` no está instalado en el entorno, por lo que no se pudo validar un build completo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d11d307e48327b32f5e453a36d1f7)