### PR TITLE
Ocultar 'Tipo' en expedientes judiciales DDHH de Justicia Provincial

### DIFF
--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -291,6 +291,10 @@ public class ExpedienteController implements Serializable {
         return isExpedienteJudicialDdhhJusticiaProvincial(selected);
     }
 
+    public boolean isExpedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial() {
+        return isExpedienteJudicialDdhhJusticiaProvincial(selectedParaVerExp);
+    }
+
     public boolean isExpedienteSeleccionadoJusticiaProvincial() {
         return selected != null && equalsIgnoreCaseTrim(selected.getEquipo(), JUSTICIA_PROVINCIAL);
     }

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -82,8 +82,8 @@
                     <p:tab title="Datos Expediente">
                         <div style="float: left; width: 50%"> 
                             <h:panelGrid columns="2" cellspacing="5">
-                                <p:outputLabel value="Tipo:" for="tipo" style="font-weight: bold"/>
-                                <p:selectOneMenu id="tipo" style="margin-left: 3%" value="#{expedienteController.selected.tipo}" >
+                                <p:outputLabel value="Tipo:" for="tipo" style="font-weight: bold" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}"/>
+                                <p:selectOneMenu id="tipo" style="margin-left: 3%" value="#{expedienteController.selected.tipo}" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}" >
                                         <f:selectItem itemLabel="Reajustes" itemValue="Reajuste" />
                                         <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
                                         <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
@@ -99,7 +99,7 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="ddhhPanel" />
+                                    <p:ajax update="@form" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">
@@ -179,7 +179,7 @@
                                          <p:selectOneMenu style="margin-left: 1%; margin-right: 1%" id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                             <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                             <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
-                                            <p:ajax update="usuarioSacPanel" />
+                                            <p:ajax update="@form usuarioSacPanel" />
                                         
                                          </p:selectOneMenu>
 

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -341,14 +341,17 @@
                                 <p:selectOneMenu  id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                     <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                     <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
+                                    <p:ajax update="@form" />
                                 </p:selectOneMenu>
 
 
                                 <p:outputLabel value="Tipo:"
-                                               for="tipo" />
+                                               for="tipo"
+                                               rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}" />
                                 <p:selectOneMenu editable="true"
                                                  id="tipo"
-                                                 value="#{expedienteController.selected.tipo}" >
+                                                 value="#{expedienteController.selected.tipo}"
+                                                 rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}" >
                                     <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
                                     <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
                                     <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
@@ -373,7 +376,7 @@
                                 <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                 <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                 <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                <p:ajax update="ddhhPanel" />
+                                <p:ajax update="@form" />
                                 </p:selectOneMenu>
 
                                 <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -338,8 +338,8 @@
                         <div class="datosexpediente">
                             <div class="columna">
 
-                                <p:outputLabel value="Tipo:" for="tipo" />
-                                <p:selectOneMenu   editable="true" id="tipo"  value="#{expedienteController.selectedParaVerExp.tipo}" >
+                                <p:outputLabel value="Tipo:" for="tipo" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial}" />
+                                <p:selectOneMenu   editable="true" id="tipo"  value="#{expedienteController.selectedParaVerExp.tipo}" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial}" >
                                     <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
                                     <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
                                     <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
@@ -357,6 +357,7 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
+                                    <p:ajax update="@form" />
                                     </p:selectOneMenu>
 
                                 <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
@@ -367,6 +368,7 @@
                                 <p:selectOneMenu  id="equipo" editable="false" effect="fold" value="#{expedienteController.selectedParaVerExp.equipo}">
                                     <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                     <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
+                                    <p:ajax update="@form" />
                                 </p:selectOneMenu>
                                 <div class="checkboxexpedientes">
 


### PR DESCRIPTION
### Motivation
- Evitar mostrar/editar el campo `tipo` cuando un expediente es `tipoDeExpediente = judicial`, `equipo = JUSTICIA PROVINCIAL` y `jpTipo = DDHH` para prevenir cambios inapropiados en ese contexto.

### Description
- Agrega el helper `isExpedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial()` en `src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java` que reutiliza la condición existente para el expediente mostrado desde la vista de agenda.
- Oculta el label y el `p:selectOneMenu` de `tipo` en las vistas judiciales cuando aplica la condición en `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/EditExpJudicial.xhtml` y `web/expediente/viewEnAgenda/EditExpJudicial.xhtml` (se usan `rendered="#{not expedienteController.expedienteSeleccionado...}"`).
- Actualiza los `p:ajax` en los selects de `jpTipo` y `equipo` para refrescar el formulario (`update="@form"`) y así recalcular la visibilidad del campo cuando cambian esos valores.

### Testing
- Ejecuté `git diff --check` y no se reportaron problemas de formato o conflictos en el diff (pasó).
- Intenté compilar con `ant -q compile` pero no se pudo ejecutar en este entorno porque `ant` no está instalado (no se ejecutó el build).
- Intenté validar XML con `xmllint --noout ...` pero no se pudo ejecutar porque `xmllint` no está instalado en el entorno (no se validaron los xhtml con esa herramienta).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d5c3b6c788327ac6ca08abbde6bc5)