### PR TITLE
Agregar panel laboral para Justicia Provincial

### DIFF
--- a/ALTER_TABLE_EXPEDIENTE_ADD_LABORAL.sql
+++ b/ALTER_TABLE_EXPEDIENTE_ADD_LABORAL.sql
@@ -1,0 +1,16 @@
+ALTER TABLE Expediente ADD COLUMN laboralTipoReclamo VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralDetalleReclamo VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralEmpleador VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralCuit VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralTrabajoRegistrado VARCHAR(10);
+ALTER TABLE Expediente ADD COLUMN laboralArt VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralFechaIngreso DATE;
+ALTER TABLE Expediente ADD COLUMN laboralFechaEgreso DATE;
+ALTER TABLE Expediente ADD COLUMN laboralDescripcionPuesto VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralJornada VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralSalario VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralCct VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralObservaciones VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralSrtTipoTramite VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralSrtExpediente VARCHAR(255);
+ALTER TABLE Expediente ADD COLUMN laboralCategoriaJuicio VARCHAR(255);

--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -62,7 +62,7 @@ public class Expediente implements Serializable {
     @Version
     @Column(name = "version")
     private Integer version;
-    
+
     @Basic(optional = false)
     @Column(name = "orden")
     private Integer orden;
@@ -77,12 +77,12 @@ public class Expediente implements Serializable {
 
     @Column(name = "nombre")
     private String nombre;
-    
+
     @Basic(optional = false)
     @Size(min = 1, max = 200)
     @Column(name = "tipoDeDocumento")
     private String tipoDeDocumento;
-    
+
     @Basic(optional = false)
     @Column(name = "sexo")
     private String sexo;
@@ -110,11 +110,11 @@ public class Expediente implements Serializable {
     @Basic(optional = false)
     @Column(name = "barrio")
     private String barrio;
-    
+
     @Basic(optional = false)
     @Column(name = "telefono")
     private String telefono;
-    
+
     @Basic(optional = false)
     @Column(name = "telefonoAuxiliar")
     private String telefonoAuxiliar;
@@ -200,11 +200,11 @@ public class Expediente implements Serializable {
     @Basic(optional = false)
     @Column(name = "observaciones")
     private String observaciones;
-    
+
     @Basic(optional = false)
     @Column(name = "responsable")
     private String responsable;
-    
+
     @Basic(optional = false)
     @Column(name = "apoderado")
     private String apoderado;
@@ -237,63 +237,63 @@ public class Expediente implements Serializable {
     @Basic(optional = false)
     @Column(name = "tipo")
     private String tipo;
-    
+
     @Basic(optional = false)
     @Column(name = "detalleDeEstadoDeTramite")
     private String detalleDeEstadoDeTramite;
-    
+
     @Basic(optional = false)
     @Column(name = "tablaDeHonorariosYGastos")
     private String tablaDeHonorariosYGastos;
-    
+
     @Column(name = "subCategoriasDeTipo")
     private String[]  subCategoriasDeTipo;
-    
+
     @Column(name = "cantidadDeHijos")
     private int  cantidadDeHijos;
-    
+
     @Column(name = "cantidadDeHijosConDiscapacidad")
     private int  cantidadDeHijosConDiscapacidad;
-    
+
     @Column(name = "cantidadDeHijosAdoptivos")
     private int  cantidadDeHijosAdoptivos;
-    
+
     @Column(name = "cantidadDeHijosPercibioAuh")
     private int  cantidadDeHijosPercibioAuh;
-    
+
     @Column(name = "estadoCivil")
     private String  estadoCivil;
 
-    @Column(name = "datosDelConyuge")    
+    @Column(name = "datosDelConyuge")
     private String datosDelConyuge;
-    
-    @Column(name = "tipoDeBeneficio")    
+
+    @Column(name = "tipoDeBeneficio")
     private String tipoDeBeneficio;
-    
-    @Column(name = "aportes")    
+
+    @Column(name = "aportes")
     private String aportes;
-    
-    @Column(name = "detalleDeAportes")    
+
+    @Column(name = "detalleDeAportes")
     private String detalleDeAportes;
-    
-    @Column(name = "trabajando")    
+
+    @Column(name = "trabajando")
     private String trabajando;
-    
-    @Column(name = "obraSocial")    
+
+    @Column(name = "obraSocial")
     private String obraSocial;
-    
-    @Column(name = "inscripcionAut")    
+
+    @Column(name = "inscripcionAut")
     private String inscripcionAut;
-    
-    @Column(name = "reclamoArt")    
+
+    @Column(name = "reclamoArt")
     private String reclamoArt;
-    
-    @Column(name = "equipo")    
+
+    @Column(name = "equipo")
     private String equipo;
-    
-    @Column(name = "activo")    
+
+    @Column(name = "activo")
     private String activo;
-    
+
     @Column(name = "fisico")
     private String fisico;
 
@@ -345,7 +345,58 @@ public class Expediente implements Serializable {
 
     @Column(name = "usuarioSac")
     private String usuarioSac;
-    
+
+    @Column(name = "laboralTipoReclamo")
+    private String laboralTipoReclamo;
+
+    @Column(name = "laboralDetalleReclamo")
+    private String laboralDetalleReclamo;
+
+    @Column(name = "laboralEmpleador")
+    private String laboralEmpleador;
+
+    @Column(name = "laboralCuit")
+    private String laboralCuit;
+
+    @Column(name = "laboralTrabajoRegistrado")
+    private String laboralTrabajoRegistrado;
+
+    @Column(name = "laboralArt")
+    private String laboralArt;
+
+    @Column(name = "laboralFechaIngreso")
+    @Temporal(TemporalType.DATE)
+    private Date laboralFechaIngreso;
+
+    @Column(name = "laboralFechaEgreso")
+    @Temporal(TemporalType.DATE)
+    private Date laboralFechaEgreso;
+
+    @Column(name = "laboralDescripcionPuesto")
+    private String laboralDescripcionPuesto;
+
+    @Column(name = "laboralJornada")
+    private String laboralJornada;
+
+    @Column(name = "laboralSalario")
+    private String laboralSalario;
+
+    @Column(name = "laboralCct")
+    private String laboralCct;
+
+    @Column(name = "laboralObservaciones")
+    private String laboralObservaciones;
+
+    @Column(name = "laboralSrtTipoTramite")
+    private String laboralSrtTipoTramite;
+
+    @Column(name = "laboralSrtExpediente")
+    private String laboralSrtExpediente;
+
+    @Column(name = "laboralCategoriaJuicio")
+    private String laboralCategoriaJuicio;
+
+
     public Expediente() {
     }
 
@@ -362,18 +413,18 @@ public class Expediente implements Serializable {
             String localidad, String tipoDeTramite, String procedencia,
             String estadoDelTramite, Date fechaDeCobro, String nacionalidad,
             String tipoDeExpediente, String caratula, String nroDeExpediente,
-            String juzgadoODependencia, String observaciones, String responsable, 
+            String juzgadoODependencia, String observaciones, String responsable,
             String apoderado, String comunicaciones, Date fechaDeAtencion,
             String convenioDeHonorarios, String jurisdiccion, String poderFirmado,
-            String tipo, String etapaProcesal, String detalleDeEstadoDeTramite, 
+            String tipo, String etapaProcesal, String detalleDeEstadoDeTramite,
             String tablaDeHonorariosYGastos, String[]  subCategoriasDeTipo,
             int cantidadDeHijos, int cantidadDeHijosConDiscapacidad,
             int cantidadDeHijosAdoptivos, int cantidadDeHijosPercibioAuh,
             String estadoCivil, String datosDelConyuge, String tipoDeBeneficio,
-            String aportes, String detalleDeAportes, String trabajando, 
+            String aportes, String detalleDeAportes, String trabajando,
             String obraSocial, String inscripcionAut, String reclamoArt,
             String equipo, String activo
-    
+
     ) {
         this.idExpediente = idExpediente;
         this.orden = orden;
@@ -429,7 +480,7 @@ public class Expediente implements Serializable {
         this.datosDelConyuge = datosDelConyuge;
         this.tipoDeBeneficio = tipoDeBeneficio;
         this.aportes = aportes;
-        
+
         this.detalleDeAportes = detalleDeAportes;
         this.trabajando = trabajando;
         this.obraSocial = obraSocial;
@@ -437,10 +488,10 @@ public class Expediente implements Serializable {
         this.reclamoArt = reclamoArt;
         this.equipo = equipo;
         this.activo = activo;
-        
-        
+
+
     }
-    
+
     public String[]  getSubCategoriasDeTipo() {
         return  subCategoriasDeTipo;
     }
@@ -448,7 +499,7 @@ public class Expediente implements Serializable {
     public void setSubCategoriasDeTipo(String[]  subCategoriasDeTipo) {
         this.subCategoriasDeTipo = subCategoriasDeTipo;
     }
-    
+
     public String getSelectedValueString() {
           return Arrays.toString(subCategoriasDeTipo);
         }
@@ -460,7 +511,7 @@ public class Expediente implements Serializable {
     public void setApoderado(String apoderado) {
         this.apoderado = apoderado;
     }
-    
+
     public Integer getIdExpediente() {
         return idExpediente;
     }
@@ -499,7 +550,7 @@ public class Expediente implements Serializable {
     public String getDni() {
         return dni;
     }
-    
+
     //ESTO LO TENGO Q HACER POR Q LOS DNI ESTÁN MAL CARGADOS LA GRAN MAYORíA
     public String getCuitRecordado() {
         if(cuit !=null && cuit.length()>=10){
@@ -550,7 +601,7 @@ public class Expediente implements Serializable {
             return null;
         }
     }
-       
+
     public void setApellido(String apellido) {
         this.apellido = apellido;
     }
@@ -742,7 +793,7 @@ public class Expediente implements Serializable {
     public void setTablaDeHonorariosYGastos(String tablaDeHonorariosYGastos) {
         this.tablaDeHonorariosYGastos = tablaDeHonorariosYGastos;
     }
-    
+
     public String getTipoDeExpedienteParaEstilo() {
         String tipoDeExpedienteParaEstilo = "no tiene tipo de exp.";
         if(tipoDeExpediente != null){
@@ -794,7 +845,7 @@ public class Expediente implements Serializable {
     public void setResponsable(String responsable) {
         this.responsable = responsable;
     }
-    
+
     public String getComunicaciones() {
         return comunicaciones;
     }
@@ -993,7 +1044,7 @@ public class Expediente implements Serializable {
     public void setFisico(String fisico) {
         this.fisico = fisico;
     }
-    
+
     public String getJpTipo() {
         return jpTipo;
     }
@@ -1142,6 +1193,39 @@ public class Expediente implements Serializable {
     public void setDdhhObservaciones(String ddhhObservaciones) { this.ddhhObservaciones = ddhhObservaciones; }
     public String getUsuarioSac() { return usuarioSac; }
     public void setUsuarioSac(String usuarioSac) { this.usuarioSac = usuarioSac; }
+    public String getLaboralTipoReclamo() { return laboralTipoReclamo; }
+    public void setLaboralTipoReclamo(String laboralTipoReclamo) { this.laboralTipoReclamo = laboralTipoReclamo; }
+    public String getLaboralDetalleReclamo() { return laboralDetalleReclamo; }
+    public void setLaboralDetalleReclamo(String laboralDetalleReclamo) { this.laboralDetalleReclamo = laboralDetalleReclamo; }
+    public String getLaboralEmpleador() { return laboralEmpleador; }
+    public void setLaboralEmpleador(String laboralEmpleador) { this.laboralEmpleador = laboralEmpleador; }
+    public String getLaboralCuit() { return laboralCuit; }
+    public void setLaboralCuit(String laboralCuit) { this.laboralCuit = laboralCuit; }
+    public String getLaboralTrabajoRegistrado() { return laboralTrabajoRegistrado; }
+    public void setLaboralTrabajoRegistrado(String laboralTrabajoRegistrado) { this.laboralTrabajoRegistrado = laboralTrabajoRegistrado; }
+    public String getLaboralArt() { return laboralArt; }
+    public void setLaboralArt(String laboralArt) { this.laboralArt = laboralArt; }
+    public Date getLaboralFechaIngreso() { return laboralFechaIngreso; }
+    public void setLaboralFechaIngreso(Date laboralFechaIngreso) { this.laboralFechaIngreso = laboralFechaIngreso; }
+    public Date getLaboralFechaEgreso() { return laboralFechaEgreso; }
+    public void setLaboralFechaEgreso(Date laboralFechaEgreso) { this.laboralFechaEgreso = laboralFechaEgreso; }
+    public String getLaboralDescripcionPuesto() { return laboralDescripcionPuesto; }
+    public void setLaboralDescripcionPuesto(String laboralDescripcionPuesto) { this.laboralDescripcionPuesto = laboralDescripcionPuesto; }
+    public String getLaboralJornada() { return laboralJornada; }
+    public void setLaboralJornada(String laboralJornada) { this.laboralJornada = laboralJornada; }
+    public String getLaboralSalario() { return laboralSalario; }
+    public void setLaboralSalario(String laboralSalario) { this.laboralSalario = laboralSalario; }
+    public String getLaboralCct() { return laboralCct; }
+    public void setLaboralCct(String laboralCct) { this.laboralCct = laboralCct; }
+    public String getLaboralObservaciones() { return laboralObservaciones; }
+    public void setLaboralObservaciones(String laboralObservaciones) { this.laboralObservaciones = laboralObservaciones; }
+    public String getLaboralSrtTipoTramite() { return laboralSrtTipoTramite; }
+    public void setLaboralSrtTipoTramite(String laboralSrtTipoTramite) { this.laboralSrtTipoTramite = laboralSrtTipoTramite; }
+    public String getLaboralSrtExpediente() { return laboralSrtExpediente; }
+    public void setLaboralSrtExpediente(String laboralSrtExpediente) { this.laboralSrtExpediente = laboralSrtExpediente; }
+    public String getLaboralCategoriaJuicio() { return laboralCategoriaJuicio; }
+    public void setLaboralCategoriaJuicio(String laboralCategoriaJuicio) { this.laboralCategoriaJuicio = laboralCategoriaJuicio; }
+
 
     public boolean equals(Object object) {
         // TODO: Warning - this method won't work in the case the id fields are not set
@@ -1158,7 +1242,7 @@ public class Expediente implements Serializable {
     public String toString() {
         return idExpediente.toString() ;
     }
-    
+
     public String toStringWithAllData() {
         return "Expediente{" + "orden=" + orden + ", cuit=" + cuit + ", dni=" + dni + ", nombre=" + nombre + ", tipoDeDocumento=" + tipoDeDocumento + ", sexo=" + sexo + ", apellido=" + apellido + ", direccion=" + direccion + ", nroDeAltura=" + nroDeAltura + ", piso=" + piso + ", depto=" + depto + ", barrio=" + barrio + ", telefono=" + telefono + ", fechaDeNacimiento=" + fechaDeNacimiento + ", edad=" + edad + ", claveSeguridadSocial=" + claveSeguridadSocial + ", claveFiscal=" + claveFiscal + ", claveCidi=" + claveCidi + ", cobraBeneficio=" + cobraBeneficio + ", fechaDeAltaDeExpediente=" + fechaDeAltaDeExpediente + ", codigoPostal=" + codigoPostal + ", localidad=" + localidad + ", tipoDeTramite=" + tipoDeTramite + ", procedencia=" + procedencia + ", estadoDelTramite=" + estadoDelTramite + ", fechaDeCobro=" + fechaDeCobro + ", nacionalidad=" + nacionalidad + ", tipoDeExpediente=" + tipoDeExpediente + ", caratula=" + caratula + ", nroDeExpediente=" + nroDeExpediente + ", juzgadoODependencia=" + juzgadoODependencia + ", observaciones=" + observaciones + ", comunicaciones=" + comunicaciones + ", fechaDeAtencion=" + fechaDeAtencion + ", convenioDeHonorarios=" + convenioDeHonorarios + ", poderFirmado=" + poderFirmado + ", etapaProcesal=" + etapaProcesal + ", jurisdiccion=" + jurisdiccion + ", tipo=" + tipo + ", detalleDeEstadoDeTramite=" + detalleDeEstadoDeTramite + ", tablaDeHonorariosYGastos=" + tablaDeHonorariosYGastos + '}';
     }
@@ -1166,5 +1250,5 @@ public class Expediente implements Serializable {
     public String toStringWithDatosPersonalesYDelExp() {
         return "orden=" + orden + "\n, cuit=" + cuit + ", dni=" + dni + ", nombre=" + nombre + ", apellido=" + apellido +", tipo de documento=" + tipoDeDocumento + ", sexo=" + sexo + ", direccion=" + direccion + ", nro de altura=" + nroDeAltura + ", piso=" + piso + ", depto=" + depto + ", barrio=" + barrio + ", telefono=" + telefono + ", fecha de nacimiento=" + fechaDeNacimiento + ", edad=" + edad + ", cobraBeneficio=" + cobraBeneficio + ", fecha de alta del Expediente=" + fechaDeAltaDeExpediente + ", codigo postal=" + codigoPostal + ", localidad=" + localidad + ", tipo de tramite=" + tipoDeTramite + ", procedencia=" + procedencia + ", estadoDelTramite=" + estadoDelTramite + ", fechaDeCobro=" + fechaDeCobro + ", nacionalidad=" + nacionalidad + ", tipoDeExpediente=" + tipoDeExpediente + ", caratula=" + caratula + ", nroDeExpediente=" + nroDeExpediente + ", juzgadoODependencia=" + juzgadoODependencia + ", observaciones=" + observaciones + ", comunicaciones=" + comunicaciones + ", fechaDeAtencion=" + fechaDeAtencion + ", convenioDeHonorarios=" + convenioDeHonorarios + ", poderFirmado=" + poderFirmado + ", etapaProcesal=" + etapaProcesal + ", jurisdiccion=" + jurisdiccion + ", tipo=" + tipo + ", detalle De estado de tramite=" + detalleDeEstadoDeTramite + ", tabla de honorarios y gastos=" + tablaDeHonorariosYGastos + '}';
     }
-    
+
 }

--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -63,7 +63,7 @@ public class ExpedienteController implements Serializable {
 
     @EJB
     private com.estudioAlvarezVersion2.jpacontroller.ExpedienteFacade ejbFacade;
-    
+
     @PersistenceContext(unitName = "EstudioAlvarezVersion2PU")
     private EntityManager em;
 
@@ -74,7 +74,7 @@ public class ExpedienteController implements Serializable {
     private Expediente selected;
     private Expediente selectedParaHonorarios;
     private Expediente selectedDesdeWithSession;
-    
+
     private Expediente selectedParaVerExp;
     private String estadoDelTramiteSelected;
     private String fechaDeCumpleSelected;
@@ -88,19 +88,20 @@ public class ExpedienteController implements Serializable {
     private List<Agenda> filteredAgendasParaHoy;
     private List<Agenda> filteredAgendasAnteriores;
     private List<Agenda> filteredAgendasFuturas;
-    
+
     private List<Agenda> filteredTurnosAnteriores;
     private List<Agenda> filteredTurnosFuturos;
-    
-    
+
+
     private List<Comunicacion> filteredComunicacionesPorNroDeOrden;
-    
+
     private Date dateSelected;
-    
+
     private static final String ADMINISTRATIVO = "administrativo";
     private static final String JUDICIAL = "judicial";
     private static final String SIN_CARPETA = "sin carpeta";
     private static final String DDHH = "DDHH";
+    private static final String LABORAL = "LABORAL";
     private static final String JUSTICIA_PROVINCIAL = "JUSTICIA PROVINCIAL";
 
 
@@ -146,7 +147,7 @@ public class ExpedienteController implements Serializable {
     public void setSelectedDesdeWithSession(Expediente selectedDesdeWithSession) {
         this.selectedDesdeWithSession = selectedDesdeWithSession;
     }
-    
+
     public void setSelectedParaHonorarios(Expediente selectedParaHonorarios) {
         this.selectedParaHonorarios = selectedParaHonorarios;
     }
@@ -201,12 +202,12 @@ public class ExpedienteController implements Serializable {
 
     public void setSelected(Expediente selected) {
         this.selected = selected;
-        
+
         // cada vez que se selecciona un expediente, vaciamos el reporte
         FacesContext context = FacesContext.getCurrentInstance();
         SituacionPrevisionalController situacionPrevisionalControllerBean = context.getApplication().evaluateExpressionGet(context, "#{situacionPrevisionalController}", SituacionPrevisionalController.class);
         situacionPrevisionalControllerBean.setTotalTiempoConAportes("");
-                
+
     }
 
     public void handleDateSelect(Date selected) {
@@ -246,7 +247,7 @@ public class ExpedienteController implements Serializable {
     public void setResponsableSelected(String responsable) {
         this.responsableSelected = responsable;
     }
-    
+
     public String getEquipoSelected() {
         return equipoSelected;
     }
@@ -286,7 +287,7 @@ public class ExpedienteController implements Serializable {
     public void setMostrarSoloActivos(boolean mostrarSoloActivos) {
         this.mostrarSoloActivos = mostrarSoloActivos;
     }
-    
+
       public boolean isExpedienteSeleccionadoJudicialDdhhJusticiaProvincial() {
         return isExpedienteJudicialDdhhJusticiaProvincial(selected);
     }
@@ -301,6 +302,22 @@ public class ExpedienteController implements Serializable {
 
     public boolean isExpedienteSeleccionadoJudicialJusticiaProvincial() {
         return isExpedienteJudicialJusticiaProvincial(selected);
+    }
+
+    public boolean isExpedienteSeleccionadoLaboralJusticiaProvincial() {
+        return isExpedienteLaboralJusticiaProvincial(selected);
+    }
+
+    public boolean isExpedienteSeleccionadoJudicialLaboralJusticiaProvincial() {
+        return isExpedienteJudicialLaboralJusticiaProvincial(selected);
+    }
+
+    public boolean isExpedienteParaVerSeleccionadoLaboralJusticiaProvincial() {
+        return isExpedienteLaboralJusticiaProvincial(selectedParaVerExp);
+    }
+
+    public boolean isExpedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial() {
+        return isExpedienteJudicialLaboralJusticiaProvincial(selectedParaVerExp);
     }
 
     private boolean isExpedienteJudicialJusticiaProvincial(Expediente expediente) {
@@ -322,6 +339,21 @@ public class ExpedienteController implements Serializable {
                 && equalsIgnoreCaseTrim(expediente.getEquipo(), JUSTICIA_PROVINCIAL);
     }
 
+    private boolean isExpedienteLaboralJusticiaProvincial(Expediente expediente) {
+        if (expediente == null) {
+            return false;
+        }
+
+        return equalsIgnoreCaseTrim(expediente.getJpTipo(), LABORAL)
+                && (equalsIgnoreCaseTrim(expediente.getEquipo(), JUSTICIA_PROVINCIAL)
+                || expediente.getEquipo() == null || expediente.getEquipo().trim().isEmpty());
+    }
+
+    private boolean isExpedienteJudicialLaboralJusticiaProvincial(Expediente expediente) {
+        return isExpedienteLaboralJusticiaProvincial(expediente)
+                && equalsIgnoreCaseTrim(expediente.getTipoDeExpediente(), JUDICIAL);
+    }
+
     private void limpiarUsuarioSacSiNoCorresponde() {
         if (selected != null && !isExpedienteJudicialJusticiaProvincial(selected)) {
             selected.setUsuarioSac(null);
@@ -331,7 +363,7 @@ public class ExpedienteController implements Serializable {
     private boolean equalsIgnoreCaseTrim(String value, String expected) {
         return value != null && expected != null && value.trim().equalsIgnoreCase(expected);
     }
-    
+
     public Expediente prepareCreateExpAdministrativo() {
         selected = new Expediente();
         selected.setTipoDeExpediente(ADMINISTRATIVO);
@@ -444,7 +476,7 @@ public class ExpedienteController implements Serializable {
         }
         return null;
     }
-    
+
     /*
         este metodo va a devolver
         administrativo
@@ -503,8 +535,8 @@ public class ExpedienteController implements Serializable {
         ingresarEdad();
 
         ingresarDni();
-        
-        if(selected.getFechaDeNacimiento() != null){ 
+
+        if(selected.getFechaDeNacimiento() != null){
             crearAgendaSaludoPorCumpleaños(selected.getFechaDeNacimiento(), selected.getOrden(), selected.getNombre(), selected.getApellido());
         }
 
@@ -513,7 +545,7 @@ public class ExpedienteController implements Serializable {
         if (selected.getTipoDeExpediente() == null ? SIN_CARPETA != null : !selected.getTipoDeExpediente().equals(SIN_CARPETA)) {
             successMessage = "Expediente del tipo: ".concat(selected.getTipoDeExpediente().toUpperCase()).concat(" creado exitosamente").concat(" con el nro de Orden: ") + selected.getOrden();
         }
-        
+
         persist(PersistAction.CREATE, successMessage);
         if (!JsfUtil.isValidationFailed()) {
             items = null;    // Invalidate list of items to trigger re-query.
@@ -636,28 +668,28 @@ public class ExpedienteController implements Serializable {
 
         Connection con = null;
         PreparedStatement ps = null;
-            
-        try {       
-            
+
+        try {
+
             long cuitLong = 0;
             String cleanCuit = normalizeCuitDigits(selected.getCuit());
 
             if (cleanCuit != null) {
                 cuitLong = Long.parseLong(cleanCuit);
             }
-            
+
                 con = DAO.getConnection();
                 ps = con.prepareStatement("INSERT INTO documentosFrenteDni (documento, nroDeOrden, nombreDelDocumento) SELECT  documento, ?, nombreDelDocumento from frenteDniExpSinCarpeta where nroDeCuit = ? ;");
                 ps.setInt(1, selected.getOrden());
                 ps.setLong(2, cuitLong);
-                
+
                 ps.execute();
 
                 ps = con.prepareStatement("INSERT INTO documentosDorsoDni (documento, nroDeOrden, nombreDelDocumento) SELECT  documento, ?, nombreDelDocumento from dorsoDniExpSinCarpeta where nroDeCuit = ? ;");
                 ps.setInt(1, selected.getOrden());
                 ps.setLong(2, cuitLong);
-                
-                
+
+
                 ps.execute();
 
                 con.close();
@@ -666,12 +698,12 @@ public class ExpedienteController implements Serializable {
             FacesMessage msg = new FacesMessage("ERROR", "no se pudo transpasar frente y dorso de dni de este exp. transformando a administrativo");
             FacesContext.getCurrentInstance().addMessage(null, msg);
         }
-        
+
         persist(PersistAction.UPDATE, "Expediente transformado a ADMINISTRATIVO con el nro de orden: " + mayorOrden);
     }
-    
+
     public void updateConCambioParaJudicial() {
-            
+
         Date fechaAntigua = new Date();
 
         if (selected.getFechaDeNacimiento() != null) {
@@ -690,35 +722,35 @@ public class ExpedienteController implements Serializable {
 
         selected.setOrden(mayorOrden);
         selected.setTipoDeExpediente(JUDICIAL);
-        
+
         Connection con = null;
         PreparedStatement ps = null;
-            
-        try {       
-            
+
+        try {
+
             long cuitLong = 0;
             String cleanCuit = normalizeCuitDigits(selected.getCuit());
 
             if (cleanCuit != null) {
                 cuitLong = Long.parseLong(cleanCuit);
             }
-            
+
                 con = DAO.getConnection();
                 ps = con.prepareStatement("INSERT INTO documentosFrenteDni (documento, nroDeOrden, nombreDelDocumento) SELECT  documento, ?, nombreDelDocumento from frenteDniExpSinCarpeta where nroDeCuit = ? ;");
                 ps.setInt(1, selected.getOrden());
                 ps.setLong(2, cuitLong);
 
-                
+
                 ps.execute();
 
                 ps = con.prepareStatement("INSERT INTO documentosDorsoDni (documento, nroDeOrden, nombreDelDocumento) SELECT  documento, ?, nombreDelDocumento from dorsoDniExpSinCarpeta where nroDeCuit = ? ;");
                 ps.setInt(1, selected.getOrden());
                 ps.setLong(2, cuitLong);
 
-                
+
                 ps.execute();
 
-                
+
                 con.close();
 
         } catch (SQLException e) {
@@ -726,8 +758,8 @@ public class ExpedienteController implements Serializable {
             FacesMessage msg = new FacesMessage("ERROR", "no se pudo transpasar frente y dorso de dni de este exp.");
             FacesContext.getCurrentInstance().addMessage(null, msg);
         }
-        
-        
+
+
         persist(PersistAction.UPDATE, "Expediente transformado a JUDICIAL con el nro de orden: " + mayorOrden);
     }
 
@@ -735,16 +767,16 @@ public class ExpedienteController implements Serializable {
 
          Integer maxOrden = em.createQuery("SELECT MAX(e.orden) FROM Expediente e", Integer.class)
             .getSingleResult();
-        
+
         // Si no hay expedientes en la base de datos, el máximo valor será null
         // En ese caso, asignar el valor 1 para el primer expediente
         if (maxOrden == null) {
             return 0;
         }
-        
+
         // Agregar 1 al máximo valor para generar un nuevo valor único
         return maxOrden + 1;
-        
+
     }
 
     public void update2() {
@@ -752,18 +784,18 @@ public class ExpedienteController implements Serializable {
     }
 
     public void destroy() {
-        
+
         HttpSession session = SessionUtils.getSession();
-        
+
         if(selected.getOrden() != null) System.out.println("nro de orden: "+selected.getOrden()+"borrado por: "+ session.getAttribute("username"));
-        
+
         persist(PersistAction.DELETE, ResourceBundle.getBundle("/Bundle").getString("ExpedienteDeleted"));
         if (!JsfUtil.isValidationFailed()) {
             selected = null; // Remove selection
             items = null;    // Invalidate list of items to trigger re-query.
         }
     }
-    
+
    public List<Expediente> getItems() {
         if (mostrarSoloActivos) {
             if (activeItems == null) {
@@ -777,7 +809,7 @@ public class ExpedienteController implements Serializable {
             return items;
         }
     }
-   
+
     private void persist(PersistAction persistAction, String successMessage) {
         if (selected != null) {
             setEmbeddableKeys();
@@ -848,21 +880,21 @@ public class ExpedienteController implements Serializable {
     public Expediente getExpediente(java.lang.Integer id) {
         return getFacade().find(id);
     }
-    
+
     public Expediente getExpedienteByNroDeOrden(java.lang.Integer orden) {
-        
+
         for (Expediente en : getFacade().findAll()) {
             if(Objects.equals(en.getOrden(), orden)){
                 return en;
             }
-            
+
         }
         return new Expediente();
     }
-    
+
     public Expediente getExpedienteByOrden(java.lang.Integer orden) {
          List<Expediente> listExpedientes = getItemsAvailableSelectMany();
-         
+
         for(int i = 0; i< listExpedientes.size(); i++){
             if(listExpedientes.get(i).getOrden() != null){
                 if(listExpedientes.get(i).getOrden().equals(orden)) return listExpedientes.get(i);
@@ -878,7 +910,7 @@ public class ExpedienteController implements Serializable {
     public List<Expediente> getItemsAvailableSelectOne() {
         return getFacade().findAll();
     }
-    
+
     public List<Expediente> getItemsAvailableSelectOneOnlyJudiciales() {
         List<Expediente> expedientes = getFacade().findAll();
         List<Expediente> expedientesJudiciales = new ArrayList<>();
@@ -893,37 +925,37 @@ public class ExpedienteController implements Serializable {
     }
 
     private void crearNuevaComunicacion(String comunicacion, Integer orden, String responsable){
-        
+
         // Obtén la fecha actual
         LocalDate fechaActual = LocalDate.now();
 
         // Convierte LocalDate a Date
         Date fechaActualDate = Date.from(fechaActual.atStartOfDay(ZoneId.systemDefault()).toInstant());
 
-        
+
         FacesContext context = FacesContext.getCurrentInstance();
         ComunicacionController comunicacionControllerBean = context.getApplication().evaluateExpressionGet(context, "#{comunicacionController}", ComunicacionController.class);
         comunicacionControllerBean.prepareCreateComunicacion(orden);
-        
+
         comunicacionControllerBean.createComunicacion(fechaActualDate, comunicacion, responsable, orden);
-        
-    
+
+
     }
-    
-    
+
+
  private void crearAgendaSaludoPorCumpleaños(Date fechaDeNacimientoDelExp, Integer orden, String nombre, String apellido) {
         // Convertir Date a LocalDate
         LocalDate fechaNacimiento = fechaDeNacimientoDelExp.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
-        
+
         // Obtener la fecha actual
         LocalDate fechaActual = LocalDate.now();
-        
+
         // Calcular el próximo cumpleaños
         LocalDate proximoCumpleaños = fechaNacimiento.withYear(fechaActual.getYear());
         if (proximoCumpleaños.isBefore(fechaActual) || proximoCumpleaños.isEqual(fechaActual)) {
             proximoCumpleaños = proximoCumpleaños.plusYears(1);
         }
-        
+
         // Convertir el próximo cumpleaños a Date
         Date fechaProximoCumpleaños = Date.from(proximoCumpleaños.atStartOfDay(ZoneId.systemDefault()).toInstant());
         String porSerFeriado = " ";
@@ -940,12 +972,12 @@ public class ExpedienteController implements Serializable {
         agendaControllerBean.getSelected().setOrden(orden);
         agendaControllerBean.getSelected().setNombre(nombre);
         agendaControllerBean.getSelected().setApellido(apellido);
-        
+
         agendaControllerBean.getSelected().setResponsable("Natali D Agostino");
-        
+
         agendaControllerBean.create(nombre, apellido, orden);
     }
- 
+
  private void crearAgendaVerConsulta(Integer orden, String nombre, String apellido, String responsable) {
 
                                 HttpSession session = (HttpSession) FacesContext.getCurrentInstance()
@@ -967,7 +999,7 @@ public class ExpedienteController implements Serializable {
 
                         Date fechaDeCreacion = dateToday; // Fecha de creación obtenida de la sesión
                         Date fechaProximoDiaHabil = getNextBusinessDay(fechaDeCreacion);
-                
+
         // Crear la agenda
         FacesContext context = FacesContext.getCurrentInstance();
         AgendaController agendaControllerBean = context.getApplication().evaluateExpressionGet(context, "#{agendaController}", AgendaController.class);
@@ -977,12 +1009,12 @@ public class ExpedienteController implements Serializable {
         agendaControllerBean.getSelected().setOrden(orden);
         agendaControllerBean.getSelected().setNombre(nombre);
         agendaControllerBean.getSelected().setApellido(apellido);
-        
+
         agendaControllerBean.getSelected().setResponsable(responsable);
-        
+
         agendaControllerBean.create(nombre, apellido, orden);
     }
- 
+
  private void crearAgendaControlarSiDimosResp(Integer orden, String nombre, String apellido, String equipo) {
 
                                 HttpSession session = (HttpSession) FacesContext.getCurrentInstance()
@@ -1003,24 +1035,24 @@ public class ExpedienteController implements Serializable {
                             }
 
                         Date fechaDeCreacion = dateToday; // Fecha de creación obtenida de la sesión
-                        
+
                         Calendar cal = Calendar.getInstance();
                         cal.setTime(fechaDeCreacion);
                         cal.add(Calendar.DATE, +14);
                         Date fechaCatorseDiasMas = cal.getTime();
-                        
+
                         Date fechaProximoDiaHabil = getNextBusinessDay(fechaCatorseDiasMas);
-                
-                        
-                        
+
+
+
                         String responsableParaAgendar = "";
-                        
+
                         if(equipo.equalsIgnoreCase("JUSTICIA FEDERAL")) responsableParaAgendar = "Paola Maldonado";
-                        
+
                         if(equipo.equalsIgnoreCase("PREVISIONAL ADMINISTRATIVO")) responsableParaAgendar = "Paula Alvarez";
-                        
+
                         if(equipo.equalsIgnoreCase("JUSTICIA PROVINCIAL")) responsableParaAgendar = "Ayelen Brizzio";
-     
+
         // Crear la agenda
         FacesContext context = FacesContext.getCurrentInstance();
         AgendaController agendaControllerBean = context.getApplication().evaluateExpressionGet(context, "#{agendaController}", AgendaController.class);
@@ -1031,11 +1063,11 @@ public class ExpedienteController implements Serializable {
         agendaControllerBean.getSelected().setNombre(nombre);
         agendaControllerBean.getSelected().setApellido(apellido);
         agendaControllerBean.getSelected().setResponsable(responsableParaAgendar);
-        
+
         agendaControllerBean.create(nombre, apellido, orden);
     }
- 
- 
+
+
  private Date getNextBusinessDay(Date date) {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
@@ -1046,7 +1078,7 @@ public class ExpedienteController implements Serializable {
 
         return calendar.getTime();
     }
-    
+
  private Boolean validateHolidays(Date date) {
     SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy"); // Formato correcto
     String dateString = sdf.format(date); // Convertir la fecha a String en el formato deseado
@@ -1076,7 +1108,7 @@ public class ExpedienteController implements Serializable {
             int dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
             return dayOfWeek == Calendar.SATURDAY || dayOfWeek == Calendar.SUNDAY;
         }
- 
+
     @FacesConverter(forClass = Expediente.class)
     public static class ExpedienteControllerConverter implements Converter {
 
@@ -1202,7 +1234,7 @@ public class ExpedienteController implements Serializable {
 
      public List verAgendasParaHoyPorNroDeOrden(Integer orden) {
       List<Agenda> agendasParaHoy = new ArrayList<Agenda>();
-      
+
         FacesContext context = FacesContext.getCurrentInstance();
         AgendaController agendaControllerBean = context.getApplication().evaluateExpressionGet(context, "#{agendaController}", AgendaController.class);
 
@@ -1225,11 +1257,11 @@ public class ExpedienteController implements Serializable {
         }
 
         return agendasParaHoy;
-      
+
      }
-    
+
     public List verAgendasFuturasPorNroDeOrden(Integer orden) {
-        
+
         List<Agenda> verAgendasFuturas = new ArrayList<Agenda>();
 
         FacesContext context = FacesContext.getCurrentInstance();
@@ -1250,7 +1282,7 @@ public class ExpedienteController implements Serializable {
                 }
             }
         }
-        
+
         //por que ahora lo hacemos por base de datos con order by
         //agendaControllerBean.ordenarListItems(verAgendasFuturas);
 
@@ -1277,12 +1309,12 @@ public class ExpedienteController implements Serializable {
                 }
             }
         }
-        
+
         Collections.reverse(verAgendasPasadas);
-        
+
         return verAgendasPasadas;
     }
-    
+
     public List verTurnosPasadosPorNroDeOrden(Integer orden) {
 
         List<Turno> verTurnosPasados = new ArrayList<Turno>();
@@ -1305,12 +1337,12 @@ public class ExpedienteController implements Serializable {
         }
 
         Collections.reverse(verTurnosPasados);
-        
+
         return verTurnosPasados;
     }
-    
+
     public List verTurnosFuturosPorNroDeOrden(Integer orden) {
-        
+
         List<Turno> verTurnosFuturos = new ArrayList<Turno>();
 
         FacesContext context = FacesContext.getCurrentInstance();
@@ -1334,15 +1366,15 @@ public class ExpedienteController implements Serializable {
 
         return verTurnosFuturos;
     }
-    
+
     public List verComunicacionesPorNroDeOrden(Integer orden) {
-        
+
         List<Comunicacion> comunicaciones;
         comunicaciones = new ArrayList<>();
 
         FacesContext context = FacesContext.getCurrentInstance();
         ComunicacionController comunicacionControllerBean = context.getApplication().evaluateExpressionGet(context, "#{comunicacionController}", ComunicacionController.class);
-            
+
         comunicacionControllerBean.getItems().stream().filter(Comunicacion ->
                 (orden != null)).filter(Comunicacion ->
                         (Comunicacion.getOrden() != null)).filter(Comunicacion ->
@@ -1350,16 +1382,16 @@ public class ExpedienteController implements Serializable {
                                 {
             comunicaciones.add(Comunicacion);
         });
-        
+
         //Collections.sort(comunicaciones, (Comunicacion o1, Comunicacion o2) -> o1.getFecha().compareTo(o2.getFecha()));
-        
+
          // Ordenar de la más reciente a la más antigua
         Collections.sort(comunicaciones, (Comunicacion o1, Comunicacion o2) -> o2.getFecha().compareTo(o1.getFecha()));
 
-        
+
         return comunicaciones;
     }
-    
+
     public List<EventoDeCausasJudiciales> verFechasJudicialesPorNroDeOrden(Integer orden) {
     List<EventoDeCausasJudiciales> eventos = new ArrayList<>();
 
@@ -1404,7 +1436,7 @@ public class ExpedienteController implements Serializable {
     return eventos;
 }
 
-    
+
     public String verClaveFiscal(int orden) {
         String claveFiscal = getFacade().findClaveFiscalByOrden(orden);
         return claveFiscal != null ? claveFiscal : "No posee clave Fiscal";
@@ -1456,7 +1488,7 @@ public class ExpedienteController implements Serializable {
     }
 
     public void filtrarPorTipoDeTramite(String tipoDeTramiteSelected) {
-        
+
         this.filteredExpedientes = new ArrayList<Expediente>();
 
         if (tipoDeTramiteSelected != null) {
@@ -1470,7 +1502,7 @@ public class ExpedienteController implements Serializable {
             }
         }
     }
-    
+
     public void filtroCompuesto(String tipoDeTramiteSelected,
             String tipoDeExpedienteSelected,
             String responsableSelected,
@@ -1488,14 +1520,14 @@ public class ExpedienteController implements Serializable {
                  .filter(ExpedienteUtils.filtroFechaDeCumple(fechaDeCumpleSelected))
                  .filter(ExpedienteUtils.filtroSexo(sexoSelected))
                  .collect(Collectors.toList());
-        
+
 
         JsfUtil.addSuccessMessage("Cantidad de ocurrencias: "+this.filteredExpedientes.size());
-        
+
     }
 
     public void filtrarPorSexo(String sexoSelected) {
-        
+
         this.filteredExpedientes = new ArrayList<Expediente>();
 
         if (sexoSelected != null) {
@@ -1511,7 +1543,7 @@ public class ExpedienteController implements Serializable {
     }
 
     public void filtrarPorTipoDeExpediente(String tipoDeExpedienteSelected) {
-        
+
         this.filteredExpedientes = new ArrayList<Expediente>();
 
         if (tipoDeExpedienteSelected != null) {
@@ -1567,7 +1599,7 @@ public class ExpedienteController implements Serializable {
                     String strDate = dateFormat.format(date);
 
                     String sSubCadena = strDate.substring(0, 5);
-                    
+
                     if (sSubCadena.equals(fechaDeCumpleSelected)) {
                         filteredExpedientes.add(expediente);
                     }
@@ -1591,8 +1623,8 @@ public class ExpedienteController implements Serializable {
 
         return apellidoYNombre.contains(filterText);
     }
-    
-    
+
+
     public void cambiarConsultaAExpAdm(Consulta consultaSelected) {
         FacesContext context = FacesContext.getCurrentInstance();
         ConsultaController consultaControllerBean = context.getApplication().evaluateExpressionGet(context, "#{consultaController}", ConsultaController.class);
@@ -1620,18 +1652,18 @@ public class ExpedienteController implements Serializable {
     if ("0".equals(consultaSelected.getCuit()) || consultaSelected.getCuit() == null || "".equals(consultaSelected.getCuit()) || consultaSelected.getCuit().isEmpty() ) {
         FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_ERROR, "Esta consulta no tiene cuit", "No es posible pasarla a exp. administrativo");
         FacesContext.getCurrentInstance().addMessage(null, facesMsg);
-    } 
-    
+    }
+
      if (consultaSelected.getResponsable() == null || consultaSelected.getResponsable().isEmpty() ||
         consultaSelected.getEquipo() == null || consultaSelected.getEquipo().isEmpty()) {
-        FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_ERROR, 
-                                                 "Faltan datos", 
+        FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                                                 "Faltan datos",
                                                  "La consulta debe tener tanto 'responsable' como 'equipo' para convertirse en expediente administrativo.");
-        
+
         FacesContext.getCurrentInstance().addMessage(null, facesMsg);
-    
+
     }
-    
+
     else {
         String dni = extractDniFromCuit(consultaSelected.getCuit());
         expAInsertar.setDni(dni);
@@ -1693,26 +1725,26 @@ public class ExpedienteController implements Serializable {
         expAInsertar.setEquipo(consultaSelected.getEquipo());
         expAInsertar.setFisico("NO");
         expAInsertar.setJpTipo(consultaSelected.getJpTipo());
-        
+
         consultaControllerBean.getSelected().setEstadoConsulta("CONSULTA PASADA A EXP. ADMINISTRATIVO");
         consultaControllerBean.getSelected().setOrden(expAInsertar.getOrden());
         consultaControllerBean.update();
         persist(JsfUtil.PersistAction.CREATE, "Consulta transformada a ADMINISTRATIVO con el nro de orden: " + expAInsertar.getOrden());
-        
+
         if(expAInsertar.getFechaDeNacimiento() != null){
             crearAgendaSaludoPorCumpleaños(expAInsertar.getFechaDeNacimiento(), expAInsertar.getOrden(), expAInsertar.getNombre(), expAInsertar.getApellido());
             crearAgendaVerConsulta( expAInsertar.getOrden(), expAInsertar.getNombre(), expAInsertar.getApellido(), expAInsertar.getResponsable());
             crearAgendaControlarSiDimosResp( expAInsertar.getOrden(), expAInsertar.getNombre(), expAInsertar.getApellido(), expAInsertar.getEquipo());
-        
+
         }else{
             FacesMessage facesMsg = new FacesMessage(FacesMessage.SEVERITY_ERROR, "Exp a insertar no tiene fecha de Nacimiento", "No es posible crear agenda de saludo de cumpleaños");
             FacesContext.getCurrentInstance().addMessage(null, facesMsg);
         }
-        
+
         if(consultaSelected.getComunicaciones() != null && !consultaSelected.getComunicaciones().trim().isEmpty()){
             crearNuevaComunicacion(consultaSelected.getComunicaciones(), expAInsertar.getOrden(), consultaSelected.getResponsable());
         }
-        
+
         items = null;
         }
     }
@@ -1731,7 +1763,7 @@ public class ExpedienteController implements Serializable {
         String url = "https://wa.me/" + telefono+"?text=hola%20me%20comunico%20del%20Estudio%20Alvarez";
         return url;
     }
-    
+
     public String verClaveCidi(int orden) {
         String claveCidi = getFacade().findClaveCidiByOrden(orden);
         return claveCidi != null ? claveCidi : "No posee clave CIDI";
@@ -1741,17 +1773,17 @@ public class ExpedienteController implements Serializable {
         String cuit = getFacade().findCuitByOrden(orden);
         return cuit != null ? cuit : "No posee CUIL/CUIT";
     }
-    
+
     public void toggleMostrarTodos() {
         mostrarSoloActivos = !mostrarSoloActivos;
         activeItems = null;  // Refrescar lista de expedientes activos
         items = null;        // Refrescar lista de todos los expedientes
     }
-    
 
-    
-    
-  
+
+
+
+
 
    public String getEdadYComparacion() {
     if (selected == null || selected.getFechaDeNacimiento() == null || selected.getSexo() == null) {
@@ -1811,7 +1843,7 @@ public class ExpedienteController implements Serializable {
     return sb.toString();
 }
 //    para mostrar iniciales de responsable
-    
+
     public String getIniciales(String nombreCompleto) {
     if (nombreCompleto == null || nombreCompleto.isEmpty()) {
         return "";

--- a/web/agenda/ViewExp_DesdeEditAgenda.xhtml
+++ b/web/agenda/ViewExp_DesdeEditAgenda.xhtml
@@ -7,11 +7,11 @@
       xmlns:p="http://primefaces.org/ui">
 
     <ui:composition>
-        
-        
-        
+
+
+
         <p:dialog id="AgendaViewExpDialog" class="editDialogExpediente" widgetVar="AgendaViewExpDialog" modal="true" header="Ver Datos Del Expediente" resizable="true" appendTo="@(body)" width="100" style="overflow-y:auto">
-            
+
             <h:form id="AgendaViewExpForm">
 
                 <div style="font-weight: bold; float: left; width: 100%; ">
@@ -25,12 +25,12 @@
 
                 <br></br><br></br>
 
-                <div style="float: left;width: 100%;">   
+                <div style="float: left;width: 100%;">
 
                     <p:tabView style="width: 100%">
-                      
- 
-                        
+
+
+
                         <p:tab title="Datos personales">
                             <h:panelGrid columns="4" cellspacing="5">
                                 <p:outputLabel value="Orden:"  style="font-weight: bold" class="float-r"/>
@@ -49,7 +49,7 @@
                                 <p:outputLabel value="#{bundle.CreateExpedienteLabel_cuit}" for="cuit" style="font-weight: bold" class="float-r"/>
                                 <p:inputText required="true" requiredMessage="CUIT ES REQUERIDO" id="cuit" value="#{expedienteController.selectedParaVerExp.cuit}" title="#{bundle.CreateExpedienteTitle_cuit}" readonly="true"/>
 
-                                <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono" style="font-weight: bold" class="float-r"/>    
+                                <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono" style="font-weight: bold" class="float-r"/>
                                 <p:inputText id="telefono" value="#{expedienteController.selectedParaVerExp.telefono}" style="margin-left: 3%" title="#{bundle.CreateExpedienteTitle_telefono}" readonly="true"/>
                             </h:panelGrid>
 
@@ -57,12 +57,12 @@
                                 <p:outputLabel value="Edad:"  style="font-weight: bold" class="float-r"/>
                                 <p:outputLabel value="#{expedienteController.selectedParaVerExp.edad}" style="font-weight: bold; margin-right: 30%;"/>
                             </h:panelGrid>
-                            <h:panelGrid columns="2" cellspacing="5" cellpadding="1">            
+                            <h:panelGrid columns="2" cellspacing="5" cellpadding="1">
                                 <p:outputLabel value="#{bundle.CreateExpedienteLabel_fechaDeNacimiento}" style="font-weight: bold" for="fechaDeNacimiento" class="float-r"/>
                                 <p:calendar  disabledWeekends="true" readonly="true" required="true" requiredMessage="Fecha de nacimiento es requerido" id="fechaDeNacimiento" pattern="dd/MM/yyyy" value="#{expedienteController.selectedParaVerExp.fechaDeNacimiento}" title="#{bundle.EditExpedienteTitle_fechaDeNacimiento}" showOn="button">
                                 </p:calendar>
                             </h:panelGrid>
-                            <h:panelGrid columns="6" cellspacing="5" >        
+                            <h:panelGrid columns="6" cellspacing="5" >
                                 <p:outputLabel value="#{bundle.CreateExpedienteLabel_sexo}" for="sexo" style="font-weight: bold" class="float-r"/>
                                 <p:selectOneMenu  style="margin-left: 3%" id="sexo" value="#{expedienteController.selectedParaVerExp.sexo}" >
                                     <f:selectItem itemLabel="Masculino" itemValue="masculino" />
@@ -83,11 +83,11 @@
                                 </p:selectOneMenu>
 
                             </h:panelGrid>
-                            <h:panelGrid columns="2" cellspacing="5" style="margin-top: 3%;"> 
+                            <h:panelGrid columns="2" cellspacing="5" style="margin-top: 3%;">
                                 <p:outputLabel value="Código_Postal:" for="codigoPostal" style="margin-left: 3%;font-weight: bold" />
                                 <p:inputText id="codigoPostal" value="#{expedienteController.selectedParaVerExp.codigoPostal}" style="margin-left: 3%;width: 71%" title="codigoPostal" readonly="true"/>
                             </h:panelGrid>
-                            <h:panelGrid columns="6" cellspacing="5" >         
+                            <h:panelGrid columns="6" cellspacing="5" >
                                 <p:outputLabel value="#{bundle.CreateExpedienteLabel_direccion}" for="direccion" style="font-weight: bold" />
                                 <p:inputText id="direccion" value="#{expedienteController.selectedParaVerExp.direccion}" title="#{bundle.CreateExpedienteTitle_direccion}" readonly="true"/>
 
@@ -105,7 +105,7 @@
 
                                 <p:outputLabel value="Localidad:" for="localidad" style="margin-left: 3%;font-weight: bold" />
                                 <p:inputText id="localidad" value="#{expedienteController.selectedParaVerExp.localidad}" style="margin-left: 3%"  title="localidad" readonly="true" />
-                            </h:panelGrid>           
+                            </h:panelGrid>
                         </p:tab>
                         <p:tab title="Datos Expediente">
                             <div style="float:left;width: 50%">
@@ -169,7 +169,7 @@
                                         <p:outputLabel value="Fecha de cobro:" for="fechaDeCobro" style="font-weight: bold" rendered="#{expedienteController.selectedParaVerExp.estadoDelTramite eq 'FECHA DE COBRO.'}" /><br></br>
                                         <p:calendar   disabledWeekends="true" style="width: 112px;" id="fechaDeCobro" pattern="dd/MM/yyyy" value="#{expedienteController.selectedParaVerExp.fechaDeCobro}" title="fechaDeCobro" rendered="#{expedienteController.selectedParaVerExp.estadoDelTramite eq 'FECHA DE COBRO.'}" />
                                     </div>
-                                    
+
                                 </div>
                                 <br></br>
 
@@ -181,7 +181,7 @@
                                 <br></br><br></br>
                                 <p:outputLabel value="Observaciones:" for="observaciones" style="font-weight: bold"/><br></br>
                                 <p:inputTextarea rows="5" cols="70" autoResize="false"  id="observaciones" value="#{expedienteController.selectedParaVerExp.observaciones}" title="observaciones" readonly="true" />
-                            </div>   
+                            </div>
                         </p:tab>
                         <p:tab title="Claves">
                             <div>
@@ -251,7 +251,7 @@
                             <div>
                                 <p:outputLabel value="Comunicaciones" for="comunicaciones" style="font-weight: bold"/><br></br>
                                  <p:editor width="700" id="comunicaciones" value="#{expedienteController.selectedParaVerExp.comunicaciones}"  ></p:editor>
-                               
+
                             </div>
 
                             <br></br>
@@ -264,10 +264,10 @@
                                         <p:outputLabel value="#{expedienteController.verProximaAgenda(expedienteController.selectedParaVerExp.orden)}" /><br></br>
                                     </p:fieldset>
                                 </div>
-                                
+
                             </div>
                         </p:tab>
-                        
+
                         <p:tab title="Honorarios y Gastos">
                             <div>
                             <p:outputLabel value="convenio de honorarios" style="font-weight: bold" for="convenioDeHonorarios" />
@@ -294,10 +294,10 @@
                             <br></br>
                             <br></br>
                             <p:editor width="700" value="#{expedienteController.selectedParaVerExp.tablaDeHonorariosYGastos}"></p:editor>
-                            </p:tab> 
+                            </p:tab>
 
- 
-                    </p:tabView>      
+
+                    </p:tabView>
                 </div>
             </h:form>
         </p:dialog>

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -7,7 +7,7 @@
       xmlns:p="http://primefaces.org/ui">
 
     <ui:composition>
-            
+
         <p:dialog id="ExpedienteCreateDlg" class="crearExpediente" widgetVar="ExpedienteCreateDialog" modal="true" resizable="true" appendTo="@(body)" header="Crear expediente Administrativo" width="100" style="overflow-y:auto">
             <h:form id="ExpedienteCreateForm">
 
@@ -15,7 +15,7 @@
                                  style="float: right !important; margin-top: 0% !important;"/>
 
 
-                <div style="float: left;width: 100%">   
+                <div style="float: left;width: 100%">
 
                     <p:tabView scrollable="true" style="width: 100%">
                         <h:panelGroup id="display"></h:panelGroup >
@@ -32,7 +32,7 @@
 
                                 <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono" style="margin-left: 3%;font-weight: bold" />
                                 <p:inputText id="telefono" value="#{expedienteController.selected.telefono}" style="margin-left: 3%" title="#{bundle.CreateExpedienteTitle_telefono}" />
-                                
+
                                 <p:outputLabel value="Telèfono Auxiliar" for="telefonoAuxiliar" style="margin-left: 3%;font-weight: bold" />
                                 <p:inputTextarea   autoResize="true"   id="telefonoAuxiliar" value="#{expedienteController.selected.telefonoAuxiliar}" title="Telèfono Auxiliar"/>
 
@@ -40,7 +40,7 @@
                             <h:panelGrid columns="4" cellspacing="5" cellpadding="1">
                                 <p:outputLabel value="Fecha de Nacimiento:" style="font-weight: bold" for="fechaDeNacimiento" />
                                 <p:calendar  required="true" requiredMessage="Fecha de nacimiento es requerido" id="fechaDeNacimiento" pattern="dd/MM/yyyy" value="#{expedienteController.selected.fechaDeNacimiento}" title="#{bundle.EditExpedienteTitle_fechaDeNacimiento}" showOn="button">
-                                </p:calendar> 
+                                </p:calendar>
                                 <p:outputLabel value="Nacionalidad:" for="nacionalidad" style="margin-left: 3%;font-weight: bold" />
                                 <p:selectOneMenu id="nacionalidad" value="#{expedienteController.selected.nacionalidad}" style="margin-left: 3%" >
                                     <f:selectItem itemLabel="Argentina" itemValue="Argentina" />
@@ -54,9 +54,9 @@
                                     <f:selectItem itemLabel="Femenino" itemValue="Femenino" />
                                     <p:ajax update="inputPanelCantHijos" />
                                 </p:selectOneMenu>
-                                
-                                
-                                
+
+
+
                             </h:panelGrid>
                             <h:panelGrid  columns="4" cellspacing="5" id="inputPanelCantHijos">
                                 <p:outputLabel value="Número total de Hijos:" rendered="#{expedienteController.selected.sexo == 'Femenino'}" />
@@ -106,7 +106,7 @@
 
                                 <p:outputLabel value="Localidad:" for="localidad" style="margin-left: 3%;font-weight: bold" />
                                 <p:inputText id="localidad" value="#{expedienteController.selected.localidad}" style="margin-left: 3%"  title="localidad"/>
-                            </h:panelGrid>       
+                            </h:panelGrid>
                             <h:panelGrid columns="2" cellspacing="5">
                                 <p:outputLabel value="Código Postal:" for="codigoPostal" style="font-weight: bold" />
                                 <p:inputText id="codigoPostal" value="#{expedienteController.selected.codigoPostal}" title="codigoPostal" style="width: 79%;"/>
@@ -124,7 +124,7 @@
                                     </p:calendar>
                                 </h:panelGrid>
 
-                                <div style="width: 50%; margin-top: 1.5%"> 
+                                <div style="width: 50%; margin-top: 1.5%">
                                     <div>
                                         <p:outputLabel value="Tipo de tramite:" for="tipoDeTramite" style="font-weight: bold" /><br></br>
 
@@ -140,7 +140,7 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="ddhhPanel" />
+                                    <p:ajax update="@form" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">
@@ -215,10 +215,20 @@
                                     </div>
 
                                 </div>
-                                <div style="width: 50%; margin-top: 1.5%"> 
+                                <div style="width: 50%; margin-top: 1.5%">
                                     <div>
-                                        <p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
-                                         
+
+
+                                    <h:panelGroup id="laboralPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoLaboralJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/laboralEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
+<p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
+
                                         <p:selectOneMenu style="margin-left: 1%; margin-right: 1%" id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                             <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                             <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
@@ -295,7 +305,7 @@
                                     <f:selectItem itemLabel="NO" itemValue="NO" />
                                     <f:selectItem itemLabel="SI" itemValue="SI" />
                                     <p:ajax update="inputAportes" />
-                                </p:selectOneMenu>   
+                                </p:selectOneMenu>
                             </h:panelGrid>
                             <h:panelGrid id="inputAportes" columns="2" cellspacing="5" >
                                 <p:outputLabel rendered="#{expedienteController.selected.aportes == 'SI'}" value="detalle de aportes:" for="detalleDeAportes" style="font-weight: bold"/><br></br>
@@ -325,7 +335,7 @@
                             <p:selectOneMenu style="margin-left: 3%" id="reclamoArt" value="#{expedienteController.selected.reclamoArt}" >
                                 <f:selectItem itemLabel="SI" itemValue="SI" />
                                 <f:selectItem itemLabel="NO" itemValue="NO" />
-                            </p:selectOneMenu>   
+                            </p:selectOneMenu>
                         </p:tab>
                         <p:tab title="Claves">
 
@@ -386,7 +396,7 @@
                             <br></br>
                             <br></br>
                             <p:editor width="700" value="#{expedienteController.selected.tablaDeHonorariosYGastos}"></p:editor>
-                        </p:tab> 
+                        </p:tab>
 
                     </p:tabView>
 

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -9,7 +9,7 @@
     <ui:composition>
 
         <p:dialog id="ExpedienteJudicialCreateDlg"  class="crearExpedienteJudicial" widgetVar="ExpedienteJudicialCreateDialog" modal="true" resizable="false" appendTo="@(body)" header="Crear Expediente Judicial">
-            <h:form id="ExpedienteJudicialCreateForm">           
+            <h:form id="ExpedienteJudicialCreateForm">
                 <p:commandButton actionListener="#{expedienteController.create}" class="botonCrearAgenda hoverGreen" value="Crear" update=":ExpedienteListForm:datalist,:growl" oncomplete="handleSubmit(args,'ExpedienteJudicialCreateDialog');"
                                  style="float: right !important; margin-top: 0% !important;"/>
 
@@ -18,7 +18,7 @@
                     </h:panelGroup >
                     <p:tab title="Datos personales">
                         <h:panelGrid columns="4" cellspacing="5">
-                            <p:outputLabel value="#{bundle.EditExpedienteLabel_apellido}" for="apellido" style="font-weight: bold" />   
+                            <p:outputLabel value="#{bundle.EditExpedienteLabel_apellido}" for="apellido" style="font-weight: bold" />
                             <p:inputText id="apellido" value="#{expedienteController.selected.apellido}" title="#{bundle.EditExpedienteTitle_apellido}" />
 
                             <p:outputLabel value="#{bundle.EditExpedienteLabel_nombre}" for="nombre" style="margin-left: 3%;font-weight: bold" />
@@ -29,13 +29,13 @@
                                 <f:validateLength minimum="11" />
                             </p:inputText>
 
-                            <p:outputLabel value="#{bundle.EditExpedienteLabel_telefono}"  for="telefono" style="margin-left: 3%;font-weight: bold" />   
+                            <p:outputLabel value="#{bundle.EditExpedienteLabel_telefono}"  for="telefono" style="margin-left: 3%;font-weight: bold" />
                             <p:inputText id="telefono" value="#{expedienteController.selected.telefono}" style="margin-left: 3%" title="#{bundle.EditExpedienteTitle_telefono}" />
-                        
+
                             <p:outputLabel value="Telèfono Auxiliar" for="telefonoAuxiliar" style="margin-left: 3%;font-weight: bold" />
                             <p:inputTextarea   autoResize="true"   id="telefonoAuxiliar" value="#{expedienteController.selected.telefonoAuxiliar}" title="Telèfono Auxiliar"/>
 
-                        
+
                         </h:panelGrid>
                         <h:panelGrid columns="2" cellspacing="5" cellpadding="1">
                             <p:outputLabel value="#{bundle.EditExpedienteLabel_fechaDeNacimiento}" for="fechaDeNacimiento" style="font-weight: bold" />
@@ -80,7 +80,7 @@
                         </h:panelGrid>
                     </p:tab>
                     <p:tab title="Datos Expediente">
-                        <div style="float: left; width: 50%"> 
+                        <div style="float: left; width: 50%">
                             <h:panelGrid columns="2" cellspacing="5">
                                 <p:outputLabel value="Tipo:" for="tipo" style="font-weight: bold" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}"/>
                                 <p:selectOneMenu id="tipo" style="margin-left: 3%" value="#{expedienteController.selected.tipo}" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}" >
@@ -174,21 +174,34 @@
                             </h:panelGrid>
                             <h:panelGrid columns="2" cellspacing="5">
                                     <div>
-                                        <p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
+
+
+                                    <h:panelGroup id="laboralPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoLaboralJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/laboralEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
+<p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
 
                                          <p:selectOneMenu style="margin-left: 1%; margin-right: 1%" id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                             <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                             <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
                                             <p:ajax update="@form usuarioSacPanel" />
-                                        
+
                                          </p:selectOneMenu>
 
 
                                     </div>
 
                             </h:panelGrid>
-                            
+
                             <h:panelGrid columns="4" cellspacing="5">
+                                <p:outputLabel value="Categoría de juicio:" for="laboralCategoriaJuicio" rendered="#{expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" />
+                                <p:inputText id="laboralCategoriaJuicio" value="#{expedienteController.selected.laboralCategoriaJuicio}" rendered="#{expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" />
+
                                 <p:outputLabel value="Nro de Expediente:" for="nroDeExpediente" style="margin-left: 6%;font-weight: bold" />
                                 <p:inputText id="nroDeExpediente" value="#{expedienteController.selected.nroDeExpediente}" title="nroDeExpediente" />
 
@@ -285,7 +298,7 @@
                     <p:tab title="Comunicaciones">
                         <p:outputLabel value="Comunicaciones" for="comunicaciones" style="font-weight: bold"/><br></br>
                         <p:editor width="700"  id="comunicaciones" value="#{expedienteController.selected.comunicaciones}" ></p:editor>
-                            
+
                     </p:tab>
                     <p:tab title="Honorarios y Gastos">
                         <div>
@@ -313,10 +326,10 @@
                         <br></br>
                         <br></br>
                         <p:editor width="700" value="#{expedienteController.selected.tablaDeHonorariosYGastos}"></p:editor>
-                        </p:tab> 
-                    
-                    
-                    
+                        </p:tab>
+
+
+
                 </p:tabView>
             </h:form>
 

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -84,16 +84,16 @@
                         <p:commandButton onclick="ExpedienteViewDialog.hide()" actionListener="#{expedienteController.update}" class="boton-guardar" value="#{bundle.Save}"
                                          update=":ExpedienteListForm:datalist" oncomplete="handleSubmit(args, 'ExpedienteEditDialog');"/>
 
-                        <p:commandButton value="Cerrar" 
+                        <p:commandButton value="Cerrar"
 
                                          styleClass="boton-cancelar"
-                                         onclick="PF('ExpedienteEditDialog').hide();" 
+                                         onclick="PF('ExpedienteEditDialog').hide();"
                                          />
                     </f:facet>
 
                 </p:toolbar>
 
-                <div style="float: left;width: 100%;">   
+                <div style="float: left;width: 100%;">
 
                     <p:tabView id="tabViewEditExpAdm" orientation="left" styleClass="tabdatospersonales" >
                         <h:panelGroup id="display">
@@ -103,13 +103,13 @@
                         <p:tab >
                             <f:facet name="title">
 
-                                <h:outputText id="iconoDatos" 
-                                              styleClass="fa fa-user" 
+                                <h:outputText id="iconoDatos"
+                                              styleClass="fa fa-user"
                                               style="font-size: 1.2rem; cursor: pointer;" />
                                 <p:tooltip for="iconoDatos" value="Datos Personales" />
 
                             </f:facet>
-                            <div class="datospersonales"> 
+                            <div class="datospersonales">
                                 <div class="columna">
                                     <p:outputLabel value="#{bundle.CreateExpedienteLabel_apellido}" for="apellido"  />
                                     <p:inputText id="apellido" value="#{expedienteController.selected.apellido}" title="#{bundle.CreateExpedienteTitle_apellido}" />
@@ -179,11 +179,11 @@
                                         <p:outputLabel value="Hijos por los que percibió AUH:" rendered="#{expedienteController.selected.sexo == 'Femenino'}" />
                                         <p:inputText rendered="#{expedienteController.selected.sexo == 'Femenino'}" value="#{expedienteController.selected.cantidadDeHijosPercibioAuh}" />
                                     </h:panelGrid>
-                                </div> 
+                                </div>
 
                                 <div class="columna">
 
-                                    <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono"  />    
+                                    <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono"  />
 
                                     <div class="telefonoinput">
                                         <p:inputText id="telefono" value="#{expedienteController.selected.telefono}" title="#{bundle.CreateExpedienteTitle_telefono}" />
@@ -194,7 +194,7 @@
                                             <img src="../faces/resources/images/whatsapp.png" ></img>
                                         </a>
                                     </div>
-                                    <p:outputLabel value="Teléfono Auxiliar" for="telefonoAuxiliar"  />            
+                                    <p:outputLabel value="Teléfono Auxiliar" for="telefonoAuxiliar"  />
                                     <p:inputTextarea    id="telefonoAuxiliar" value="#{expedienteController.selected.telefonoAuxiliar}" cols="22" title="Telèfono Auxiliar" style="height: 21px;"/>
                                     <p:outputLabel value="Email:" for="email"  />
                                     <p:inputText id="email" value="#{expedienteController.selected.email}" title="Email" />
@@ -240,13 +240,13 @@
                                     <p:selectOneMenu   id="inscripcionAut" value="#{expedienteController.selected.inscripcionAut}" >
                                         <f:selectItem itemLabel="SI" itemValue="SI" />
                                         <f:selectItem itemLabel="NO" itemValue="NO" />
-                                    </p:selectOneMenu>   
+                                    </p:selectOneMenu>
 
                                     <p:outputLabel  value="Posible Reclamo ART: " for="reclamoArt" />
                                     <p:selectOneMenu id="reclamoArt" value="#{expedienteController.selected.reclamoArt}" >
                                         <f:selectItem itemLabel="SI" itemValue="SI" />
                                         <f:selectItem itemLabel="NO" itemValue="NO" />
-                                    </p:selectOneMenu>   
+                                    </p:selectOneMenu>
 
                                     <p:outputLabel value="Expediente físico:" for="fisico" style="font-weight: bold" />
                                     <p:selectOneMenu id="fisico" value="#{expedienteController.selected.fisico}">
@@ -273,7 +273,7 @@
                                         <f:selectItem itemLabel="NO" itemValue="NO" />
                                         <f:selectItem itemLabel="SI" itemValue="SI" />
                                         <p:ajax update="inputAportes" />
-                                    </p:selectOneMenu>   
+                                    </p:selectOneMenu>
 
                                     <h:panelGrid id="inputAportes" columns="1"
                                                  cellpadding="0"
@@ -287,7 +287,7 @@
                                             <f:selectItem itemLabel="NO" itemValue="NO" />
                                             <f:selectItem itemLabel="SI" itemValue="SI" />
                                             <p:ajax update="inputObraSocial" />
-                                        </p:selectOneMenu>   
+                                        </p:selectOneMenu>
 
                                     </h:panelGrid  >
                                     <h:panelGrid id="inputObraSocial" columns="1"
@@ -299,9 +299,9 @@
                                     </h:panelGrid>
 
                                 </div>
-                                <div  class="columna"> 
+                                <div  class="columna">
 
-                                    <div class="roww1"> 
+                                    <div class="roww1">
                                         <div class="imagenentidad">
                                             <a href="https://servicioscorp.anses.gob.ar/clavelogon/logon.aspx?system=miansesv2" target="_blank" >
                                                 <img src="../faces/resources/images/anses.png" ></img>
@@ -315,7 +315,7 @@
 
                                         </div>
                                     </div>
-                                    <div class="roww1"> 
+                                    <div class="roww1">
                                         <div class="arca" >
                                             <a href="https://auth.afip.gob.ar/contribuyente_/login.xhtml" target="_blank" >
                                                 <img src="../faces/resources/images/arca.jpg"  ></img>
@@ -350,8 +350,8 @@
                         <p:tab >
                             <f:facet name="title">
 
-                                <h:outputText id="iconoEXP"  
-                                              styleClass="fa fa-folder" 
+                                <h:outputText id="iconoEXP"
+                                              styleClass="fa fa-folder"
                                               style="font-size: 1.2rem; cursor: pointer;" />
                                 <p:tooltip for="iconoEXP" value="Datos del expediente" />
 
@@ -380,7 +380,7 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="ddhhPanel" />
+                                    <p:ajax update="@form" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                     <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}">
@@ -458,7 +458,17 @@
 
 
 
-                                    <p:outputLabel value="Equipo:" for="equipo"  />
+
+
+                                    <h:panelGroup id="laboralPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoLaboralJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/laboralEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
+<p:outputLabel value="Equipo:" for="equipo"  />
                                     <p:selectOneMenu id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                         <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                         <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
@@ -512,7 +522,7 @@
                                                                                                                                                                expedienteController.selected.telefono,
                                                                                                                                                                expedienteController.selected.cuit,
                                                                                                                                                                expedienteController.selected.fechaDeNacimiento,
-                                                                                                                                                               expedienteController.selected.edad, 
+                                                                                                                                                               expedienteController.selected.edad,
                                                                                                                                                                expedienteController.selected.cobraBeneficio,
                                                                                                                                                                expedienteController.selected.tipoDeBeneficio,
                                                                                                                                                                expedienteController.selected.aportes,
@@ -541,9 +551,9 @@
 
                                 <div style="text-align: right ; padding-bottom: 20px ;display: grid;" >
                                     <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
-                                                      actionListener="#{comunicacionController.prepareCreateComunicacion(expedienteController.selected.orden)}"  value="crear comunicación" 
+                                                      actionListener="#{comunicacionController.prepareCreateComunicacion(expedienteController.selected.orden)}"  value="crear comunicación"
                                                       update=":ComunicacionCreateFormExpAdm" oncomplete="PF('ComunicacionCreateDialogExpAdm').show()" />
-                                </div>     
+                                </div>
 
                                 <p:dataTable id="datalist4"
                                              value="#{expedienteController.verComunicacionesPorNroDeOrden(expedienteController.selected.orden)}" var="item"
@@ -553,11 +563,11 @@
                                              rows="10"
                                              widgetVar="comunicacionesTable2"
                                              rowsPerPageTemplate="10,20,50"
-                                             emptyMessage="no hay comunicaciones agregadas" 
-                                             rendered="true"  
+                                             emptyMessage="no hay comunicaciones agregadas"
+                                             rendered="true"
                                              style="display: table;"
                                              styleClass="tabla-tailwind"
-                                             sortBy="#{item.fecha}" sortOrder="descending" 
+                                             sortBy="#{item.fecha}" sortOrder="descending"
                                              >
 
                                     <p:ajax event="rowSelect"  />
@@ -579,7 +589,7 @@
 
                                     <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                         <div style="display:flex;justify-content: center">
-                                            <h:outputText id="responsableicon"  
+                                            <h:outputText id="responsableicon"
                                                           value="#{expedienteController.getIniciales(item.responsable)}"
                                                           style="color:white; border-radius:50%; width:28px; height:28px;
                                                           display:flex; align-items:center; justify-content:center;
@@ -603,16 +613,16 @@
                                         <p:commandButton class="linea btnDelete" update=":growl,datalist4" oncomplete="PF('expedientesTable').clearFilters()" actionListener="#{comunicacionController.destroy}"  icon="ui-icon-trash" title="Eliminar">
                                             <f:setPropertyActionListener value="#{item}" target="#{comunicacionController.selected}" />
                                             <p:confirm header="Confirmación" message="¿Estas seguro?"  icon="ui-icon-alert"/>
-                                        </p:commandButton> 
+                                        </p:commandButton>
 
-                                    </p:column>    
+                                    </p:column>
 
                                 </p:dataTable>
 
                                 <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                     <p:commandButton update=":ExpedienteListForm" value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;" />
                                     <p:commandButton update=":ExpedienteListForm" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;" />
-                                </p:confirmDialog> 
+                                </p:confirmDialog>
 
                             </div>
                         </p:tab>
@@ -626,7 +636,7 @@
 
                                 <p:commandButton id="createButtonTurno"
                                                  class="boton-guardar hoverBlue "
-                                                 value="Crear Turno" 
+                                                 value="Crear Turno"
                                                  actionListener="#{turnoController.prepareCreate}"
                                                  update=":ExpedienteViewFormParaTurno,:growl"
                                                  oncomplete="PF('ExpedienteViewDialogParaTurno').show(); PF('ExpedienteEditDialog').show()" />
@@ -634,21 +644,21 @@
                                 <p:commandButton id="createButtonAgenda"
                                                  class="boton-sistema hoverBlue" style="margin-right: 10px !important;
                                                  margin-left: 10px;"
-                                                 value="Crear Agenda" 
+                                                 value="Crear Agenda"
                                                  actionListener="#{agendaController.prepareCreate}"
                                                  update=":ExpedienteViewFormParaAgenda,:growl"
                                                  oncomplete="PF('ExpedienteViewDialogParaAgenda').show(); PF('ExpedienteEditDialog').show()" />
                                 <p:commandButton
                                     id="createButtonAgendasMasivas"
                                     class="boton-agenda-masiva"  style="margin-left: 10px;"
-                                    value="Crear Agendas Masivas" 
+                                    value="Crear Agendas Masivas"
                                     actionListener="#{agendaController.prepareCreateAgendasMasivas}"
                                     update=":ExpedienteViewFormParaAgendaMasiva,:growl"
                                     oncomplete="PF('ExpedienteViewDialogParaAgendasMasivas').show(); PF('ExpedienteEditDialog').show()" />
 
 
                                 <p:fieldset class="tablashistorial" legend="AGENDAS ANTERIORES" toggleable="true"  collapsed="true" toggleSpeed="500">
-                                    <p:dataTable id="datalist3" 
+                                    <p:dataTable id="datalist3"
                                                  value="#{expedienteController.verAgendasPasadasPorNroDeOrden(expedienteController.selected.orden)}"
                                                  var="item"
                                                  selectionMode="single"
@@ -658,7 +668,7 @@
                                                  rendered="true"
                                                  rows="10"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay agendas Pasadas agregadas" 
+                                                 emptyMessage="no hay agendas Pasadas agregadas"
                                                  filteredValue="#{expedienteController.filteredAgendasAnteriores}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -674,7 +684,7 @@
                                         </p:column>
                                         <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -703,14 +713,14 @@
                                             </p:commandButton>
 
                                             <p:commandButton class="linea btnKeyGreen"
-                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalist3" 
+                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalist3"
                                                              actionListener="#{agendaController.marcarComoRealizadaSiAgendaPasada()}"
                                                              icon=" ui-icon-check" title="Marcar como realizado si">
                                                 <f:setPropertyActionListener value="#{item}" target="#{agendaController.selectedAgendaPasada}" />
                                             </p:commandButton>
 
                                             <p:commandButton class="linea btnDelete"
-                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalist3, message3" 
+                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalist3, message3"
                                                              actionListener="#{agendaController.destroyAgendaPasada()}"  icon="ui-icon-trash" title="Eliminar">
                                                 <f:setPropertyActionListener value="#{item}" target="#{agendaController.selectedAgendaPasada}" />
                                                 <p:confirm header="Confirmación" message="¿Estas seguro?" icon="ui-icon-alert"/>
@@ -719,23 +729,23 @@
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                                 <p:commandButton   update=":ExpedienteEditForm:tabViewEditExpAdm:datalist3"  value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
 
                                     </p:dataTable>
                                 </p:fieldset>
                                 <p:fieldset class="tablashistorial" legend="TURNOS ANTERIORES" toggleable="true"  collapsed="true" toggleSpeed="500">
-                                    <p:dataTable id="datalistTurnosAnteriores" 
+                                    <p:dataTable id="datalistTurnosAnteriores"
                                                  value="#{expedienteController.verTurnosPasadosPorNroDeOrden(expedienteController.selected.orden)}"
                                                  var="item"
                                                  selectionMode="single"
                                                  selection="#{turnoController.selectedTurnoPasado}"
                                                  rowKey="#{item.idTurno}"
-                                                 paginator="true"    
+                                                 paginator="true"
                                                  rendered="true"
                                                  rows="10"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay turnos Pasados agregados" 
+                                                 emptyMessage="no hay turnos Pasados agregados"
                                                  filteredValue="#{expedienteController.filteredTurnosAnteriores}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -760,18 +770,18 @@
                                                     <f:selectItem itemLabel="Pendiente" itemValue="Pendiente" />
                                                 </p:selectOneMenu>
                                             </f:facet>
-                                            <div class="apilarelementos"> 
+                                            <div class="apilarelementos">
                                                 <h:outputText value="#{item.realizado eq 'Si' ? 'Realizado' : (item.realizado eq 'Pendiente' ? 'Pendiente' : 'Por Atender')}" styleClass="estadofinalizado#{item.realizado}" />
 
                                                 <h:outputText  value="#{item.horaYDia}" styleClass="fechacolumna" >
                                                     <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
                                                 </h:outputText>
-                                            </div> 
+                                            </div>
                                         </p:column>
                                         <p:column filterBy="#{item.responsable}" headerText="Responsable"  filterMatchMode="contains" style="width:10%" class="iconoturnorespondable" >
 
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -786,14 +796,14 @@
                                         <p:column  style="text-align: center; width: 10%" headerText="Acciones">
 
                                             <p:commandButton class="linea btnKeyGreen"
-                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosAnteriores" 
+                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosAnteriores"
                                                              actionListener="#{turnoController.marcarComoRealizadoSiTurnoPasado()}"
                                                              icon=" ui-icon-check" title="Marcar como realizado si">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoPasado}" />
                                             </p:commandButton>
 
                                             <p:commandButton class="linea btnDelete"
-                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosAnteriores, message3" 
+                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosAnteriores, message3"
                                                              actionListener="#{turnoController.destroyTurnoPasado()}"  icon="ui-icon-trash" title="Eliminar">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoPasado}" />
                                                 <p:confirm header="Confirmación" message="¿Estas seguro?" icon="ui-icon-alert"/>
@@ -802,7 +812,7 @@
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                                 <p:commandButton   update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosAnteriores"  value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
 
                                     </p:dataTable>
@@ -810,8 +820,8 @@
 
                                 <p:fieldset class="tablashistorial" legend="AGENDAS FUTURAS" toggleable="true"  collapsed="true" toggleSpeed="500">
 
-                                    <p:dataTable id="datalist2" 
-                                                 value="#{expedienteController.verAgendasFuturasPorNroDeOrden(expedienteController.selected.orden)}" 
+                                    <p:dataTable id="datalist2"
+                                                 value="#{expedienteController.verAgendasFuturasPorNroDeOrden(expedienteController.selected.orden)}"
                                                  var="item"
                                                  selectionMode="single"
                                                  selection="#{agendaController.selectedAgendaFutura}"
@@ -820,7 +830,7 @@
                                                  rows="10"
                                                  rendered="true"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay agendas futuras agregadas" 
+                                                 emptyMessage="no hay agendas futuras agregadas"
                                                  filteredValue="#{expedienteController.filteredAgendasFuturas}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -838,7 +848,7 @@
                                         </p:column>
                                         <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -878,17 +888,17 @@
                                             </p:commandButton>
 
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
-                                                <p:commandButton   update=":ExpedienteEditForm:tabViewEditExpAdm:datalist2" 
+                                                <p:commandButton   update=":ExpedienteEditForm:tabViewEditExpAdm:datalist2"
                                                                    value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
                                     </p:dataTable>
                                 </p:fieldset>
                                 <p:fieldset class="tablashistorial" legend="TURNOS FUTUROS" toggleable="true"  collapsed="true" toggleSpeed="500">
 
-                                    <p:dataTable id="datalistTurnosFuturos" 
-                                                 value="#{expedienteController.verTurnosFuturosPorNroDeOrden(expedienteController.selected.orden)}" 
+                                    <p:dataTable id="datalistTurnosFuturos"
+                                                 value="#{expedienteController.verTurnosFuturosPorNroDeOrden(expedienteController.selected.orden)}"
                                                  var="item"
                                                  selectionMode="single"
                                                  selection="#{turnoController.selectedTurnoFuturo}"
@@ -897,7 +907,7 @@
                                                  rows="10"
                                                  rendered="true"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay turnos futuros agregados" 
+                                                 emptyMessage="no hay turnos futuros agregados"
                                                  filteredValue="#{expedienteController.filteredTurnosFuturos}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -923,18 +933,18 @@
                                                     <f:selectItem itemLabel="Pendiente" itemValue="Pendiente" />
                                                 </p:selectOneMenu>
                                             </f:facet>
-                                            <div class="apilarelementos"> 
+                                            <div class="apilarelementos">
                                                 <h:outputText value="#{item.realizado eq 'Si' ? 'Realizado' : (item.realizado eq 'Pendiente' ? 'Pendiente' : 'Por Atender')}" styleClass="estadofinalizado#{item.realizado}" />
 
                                                 <h:outputText  value="#{item.horaYDia}" styleClass="fechacolumna" >
                                                     <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
                                                 </h:outputText>
-                                            </div> 
+                                            </div>
                                         </p:column>
                                         <p:column filterBy="#{item.responsable}" headerText="Responsable"  filterMatchMode="contains" style="width:10%" class="iconoturnorespondable" >
 
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -948,14 +958,14 @@
                                         <p:column  style="text-align: center; width: 10%" headerText="Acciones">
 
                                             <p:commandButton class="linea btnKeyGreen"
-                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosFuturos" 
+                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosFuturos"
                                                              actionListener="#{turnoController.marcarComoRealizadoSiTurnoFuturo()}"
                                                              icon=" ui-icon-check" title="Marcar como realizado si">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoFuturo}" />
                                             </p:commandButton>
 
                                             <p:commandButton class="linea btnDelete"
-                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosFuturos, message4" 
+                                                             update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosFuturos, message4"
                                                              actionListener="#{turnoController.destroyTurnoFuturo()}"  icon="ui-icon-trash" title="Eliminar">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoFuturo}" />
                                                 <p:confirm header="Confirmación" message="¿Estas seguro?" icon="ui-icon-alert"/>
@@ -964,7 +974,7 @@
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                                 <p:commandButton   update=":ExpedienteEditForm:tabViewEditExpAdm:datalistTurnosFuturos"  value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
 
                                     </p:dataTable>
@@ -1006,7 +1016,7 @@
                             </div>
                             <div class="editordetexto">
                                 <p:editor  value="#{expedienteController.selected.tablaDeHonorariosYGastos}"></p:editor>
-                            </div>  
+                            </div>
                         </p:tab>
 
                         <p:tab >
@@ -1018,7 +1028,7 @@
                             <div class="comunicaciones">
 
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar" style="margin-bottom: 20px;"
-                                                  actionListener="#{situacionPrevisionalController.prepareCreateSituacionPrevisional(expedienteController.selected.orden)}"  value="crear situación previsional" 
+                                                  actionListener="#{situacionPrevisionalController.prepareCreateSituacionPrevisional(expedienteController.selected.orden)}"  value="crear situación previsional"
                                                   update=":SituacionPrevisionalCreateFormExpAdm" oncomplete="PF('SituacionPrevisionalCreateDialogExpAdm').show()" />
                                 <p:dataTable id="datalistSituacionPrevisional"
                                              value="#{situacionPrevisionalController.verSituacionPrevisionalesPorNroDeOrden(expedienteController.selected.orden)}"
@@ -1030,7 +1040,7 @@
                                              rows="10"
                                              rendered="true"
                                              rowsPerPageTemplate="10,20,50"
-                                             emptyMessage="no hay situaciones previsionales agregadas" 
+                                             emptyMessage="no hay situaciones previsionales agregadas"
                                              style="display: table;padding: 20px"
                                              styleClass="tabla-tailwind"
                                              >
@@ -1073,7 +1083,7 @@
 
                                         <p:commandButton class="linea btnDelete" update=":growl,datalistSituacionPrevisional" oncomplete="PF('expedientesTable').clearFilters()" actionListener="#{situacionPrevisionalController.destroy}"  icon="ui-icon-trash" title="Eliminar">
                                             <f:setPropertyActionListener value="#{item}" target="#{situacionPrevisionalController.selected}" />
-                                        </p:commandButton> 
+                                        </p:commandButton>
 
                                     </p:column>
 
@@ -1087,7 +1097,7 @@
                                         <p:ajax update="panelCodigoEvaluacionSocioeconomica"/>
                                     </p:selectBooleanCheckbox>
 
-                                    <h:outputLabel for="btnCompraLey24476" 
+                                    <h:outputLabel for="btnCompraLey24476"
                                                    value="Compra aportes con moratoria Ley 24.476" />
                                 </div>
 
@@ -1133,17 +1143,17 @@
                                                      autoResize="true"
                                                      style="margin-left:10px;margin-right: 10px !important;"
                                                      rows="20"
-                                                     value="#{empty situacionPrevisionalController.totalTiempoConAportes 
-                                                              ? '' 
+                                                     value="#{empty situacionPrevisionalController.totalTiempoConAportes
+                                                              ? ''
                                                               : situacionPrevisionalController.totalTiempoConAportes.trim()}" />
                                 </h:panelGroup>
 
 
                             </div>
-                        </p:tab>  
+                        </p:tab>
                     </p:tabView>
                 </div>
-            </h:form>    
+            </h:form>
         </p:dialog>
 
         <ui:include src="../comunicacion/CreateComunicacionParaExpAdministrativo.xhtml"/>

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -446,7 +446,17 @@
                                     </h:panelGroup>
                                 </h:panelGroup>
 
-                                <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
+
+
+                                <h:panelGroup id="laboralPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                    <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoLaboralJusticiaProvincial}">
+                                        <ui:include src="/expediente/fragments/laboralEdit.xhtml">
+                                            <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                        </ui:include>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
+<p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
                                     <p:commandButton value="Si" type="button" styleClass="ui-confirmdialog-no" icon="pi pi-times" update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm" />
                                 </p:confirmDialog>
                                 <div class="checkboxexpedientes">
@@ -509,6 +519,9 @@
 
                             </div>
                             <div class="columna">
+
+                                <p:outputLabel value="Categoría de juicio:" for="laboralCategoriaJuicio" rendered="#{expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" />
+                                <p:inputText id="laboralCategoriaJuicio" value="#{expedienteController.selected.laboralCategoriaJuicio}" rendered="#{expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" />
 
                                 <p:outputLabel value="Nº de Expediente:" for="nroDeExpediente"  />
                                 <p:inputText id="nroDeExpediente" value="#{expedienteController.selected.nroDeExpediente}"

--- a/web/expediente/ViewExpJudicial.xhtml
+++ b/web/expediente/ViewExpJudicial.xhtml
@@ -9,57 +9,57 @@
     <ui:composition>
 
         <p:dialog id="ExpedienteJudicialViewDlg" widgetVar="ExpedienteJudicialViewDialog" modal="true" resizable="false" appendTo="@(body)" header="Ver Claves">
-            
+
             <h:form id="ExpedienteViewClavesForm">
                 <h:panelGroup id="display">
-                    
+
                    <p:fieldset legend="datos personales" toggleable="true" toggleSpeed="500">
-                       
+
                     <p:panel  style="margin-bottom:2px">
-                          
+
                         <p:panel>
                             <h:panelGrid columns="10" cellpadding="1" rendered="#{expedienteController.selected != null}">
-                                
+
                                 <h:outputText value="Orden:" style="font-weight: bold; " />
                                 <h:outputText value="#{expedienteController.selected.orden}"/>
-                                
+
                                <h:outputText value="#{bundle.ViewExpedienteLabel_apellido}" style="font-weight: bold; " />
                                 <h:outputText value="#{expedienteController.selected.apellido}" title="#{bundle.ViewExpedienteTitle_apellido}"/>
-                            
+
                                 <h:outputText value="#{bundle.ViewExpedienteLabel_nombre}" style="font-weight: bold" />
                                 <h:outputText value="#{expedienteController.selected.nombre}" title="#{bundle.ViewExpedienteTitle_nombre}"/>
-                       
+
                                 <h:outputText value="Dni:" style="font-weight: bold" />
                                 <h:outputText value="#{expedienteController.selected.dni}" title="Dni"/>
-                            
+
                                 <h:outputText value="#{bundle.ViewExpedienteLabel_cuit}" style="font-weight: bold" />
                                 <h:outputText value="#{expedienteController.selected.cuit}" title="#{bundle.ViewExpedienteTitle_cuit}"/>
-                            </h:panelGrid>        
-                           
+                            </h:panelGrid>
+
                             <h:panelGrid columns="10" cellpadding="1" rendered="#{expedienteController.selected != null}">
 
                                 <h:outputText value="Nacionalidad:" style="font-weight: bold" />
                                 <h:outputText value="#{expedienteController.selected.nacionalidad}" title="nacionalidad"/>
-                            
+
                                 <h:outputText value="Tipo de expediente:"  style="font-weight: bold" />
                                 <h:outputText value="#{expedienteController.selected.tipoDeExpediente}" title="tipoDeExpediente"/>
-                            
+
                                 <h:outputText value="Fecha de alta de expediente:" style="font-weight: bold" />
                                 <h:outputText value="#{expedienteController.selected.fechaDeAltaDeExpediente}" title="fecha de alta de expediente">
                                         <f:convertDateTime pattern="dd/MM/yyyy" />
                                 </h:outputText>
-                            
+
                                 <h:outputText value="Fecha de atención:" style="font-weight: bold" />
                                 <h:outputText value="#{expedienteController.selected.fechaDeAtencion}" title="fechaDeAtencion">
                                     <f:convertDateTime pattern="dd/MM/yyyy" />
                                 </h:outputText>
                             </h:panelGrid>
-                               
-                    
+
+
                      </p:panel>
-                        
+
                     <br></br>
-                    
+
                     <p:panel>
                     <h:panelGroup  rendered="#{expedienteController.selected != null}">
                         <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
@@ -68,13 +68,13 @@
 
                             <h:outputText value="Altura:" style="font-weight: bold" />
                             <h:outputText value="#{expedienteController.selected.nroDeAltura}" title="#{bundle.ViewExpedienteTitle_nroDeAltura}"/>
-                        
-                                
+
+
                             <h:outputText value="#{bundle.ViewExpedienteLabel_piso}" style="font-weight: bold" />
                             <h:outputText value="#{expedienteController.selected.piso}" title="#{bundle.ViewExpedienteTitle_piso}"/>
-                        </h:panelGrid>    
+                        </h:panelGrid>
                         <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
-                            
+
                             <h:outputText value="#{bundle.ViewExpedienteLabel_depto}" style="font-weight: bold" />
                             <h:outputText value="#{expedienteController.selected.depto}" title="#{bundle.ViewExpedienteTitle_depto}"/>
 
@@ -86,13 +86,13 @@
 
                             <h:outputText value="Localidad:" style="font-weight: bold" />
                             <h:outputText value="#{expedienteController.selected.localidad}" title="localidad"/>
-                        </h:panelGrid>    
-                        
-                    </h:panelGroup>   
-                    </p:panel> 
-                    
+                        </h:panelGrid>
+
+                    </h:panelGroup>
                     </p:panel>
-                    
+
+                    </p:panel>
+
                     <p:panel  style="margin-bottom:2px">
                         <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
 
@@ -107,44 +107,56 @@
                             <h:outputText value="#{bundle.ViewExpedienteLabel_edad}" style="font-weight: bold" />
                             <h:outputText value="#{expedienteController.selected.edad}" title="#{bundle.ViewExpedienteTitle_edad}"/>
 
-                        </h:panelGrid>   
-                    
+                        </h:panelGrid>
+
                     <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
-                        
+
                         <h:outputText value="Tipo de tramite:" style="font-weight: bold" />
                         <h:outputText value="#{expedienteController.selected.tipoDeTramite}" title="tipoDeTramite"/>
                             <h:outputText value="JP Tipo:"/>
                             <h:outputText value="#{expedienteController.selected.jpTipo}" title="jpTipo" class="negrita"/>
-                    
+
                         <h:outputText value="Estado del tramite:" style="font-weight: bold" />
                         <h:outputText value="#{expedienteController.selected.estadoDelTramite}" title="estadoDelTramite"/>
 
                         <h:outputText value="Cobra  Beneficio:" style="font-weight: bold" />
                         <h:outputText value="#{expedienteController.selected.cobraBeneficio}" title="cobra beneficio"/>
-                        
+
                         <h:outputText value="Expediente físico:" style="font-weight: bold" />
                         <h:outputText value="#{expedienteController.selected.fisico}" title="expediente fisico"/>
 
                         <h:outputText value="#{bundle.ViewExpedienteLabel_sexo}" style="font-weight: bold" />
                         <h:outputText value="#{expedienteController.selected.sexo}" title="#{bundle.ViewExpedienteTitle_sexo}"/>
-                    
-                    </h:panelGrid>   
-                    
+
+                    </h:panelGrid>
+
                     <br></br>
-                    
+
+                    <p:fieldset legend="Datos laborales" toggleable="true" toggleSpeed="500" rendered="#{expedienteController.expedienteSeleccionadoLaboralJusticiaProvincial}">
+                        <ui:include src="/expediente/fragments/laboralView.xhtml">
+                            <ui:param name="expediente" value="#{expedienteController.selected}" />
+                        </ui:include>
+                        <h:panelGrid columns="4" cellspacing="5" rendered="#{expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}">
+                            <h:outputText value="Categoría de juicio:" style="font-weight: bold" />
+                            <h:outputText value="#{expedienteController.selected.laboralCategoriaJuicio}" />
+                            <h:outputText value="Usuario SAC:" style="font-weight: bold" />
+                            <h:outputText value="#{expedienteController.selected.usuarioSac}" />
+                        </h:panelGrid>
+                    </p:fieldset>
+
                     <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
                         <h:outputText value="Observaciones:" style="font-weight: bold" />
-                    </h:panelGrid>   
-                    
+                    </h:panelGrid>
+
                     <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
                         <h:outputText  value="#{expedienteController.selected.observaciones}" title="observaciones"/>
                     </h:panelGrid>
-                 </p:panel>          
-                </p:fieldset> 
+                 </p:panel>
+                </p:fieldset>
                     <br></br>
                   <p:fieldset legend="Claves" toggleable="true" toggleSpeed="500">
-                     
-                    <p:panel  style="margin-bottom:2px" rendered="#{expedienteController.selected.tipoDeExpediente eq 'judicial'}">  
+
+                    <p:panel  style="margin-bottom:2px" rendered="#{expedienteController.selected.tipoDeExpediente eq 'judicial'}">
                         <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
 
                             <h:outputText value="Caratula:" style="font-weight: bold" rendered="#{expedienteController.selected.tipoDeExpediente eq 'judicial'}"/>
@@ -155,13 +167,13 @@
 
                             <h:outputText value="Juzgado O Dependencia:" style="font-weight: bold" rendered="#{expedienteController.selected.tipoDeExpediente eq 'judicial'}" />
                             <h:outputText value="#{expedienteController.selected.juzgadoODependencia}" title="juzgadoODependencia" rendered="#{expedienteController.selected.tipoDeExpediente eq 'judicial'}" />
-                            
-                            
+
+
                             <button><a  href="https://scw.pjn.gov.ar/scw/home.seam" target="_blank">Link Para Judiciales</a></button>
 
                         </h:panelGrid>
-                    </p:panel>         
-                      
+                    </p:panel>
+
                     <p:panel  style="margin-bottom:2px">
                         <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
                             <h:outputText value="C de SS:" style="font-weight: bold" />
@@ -176,39 +188,39 @@
                             <h:outputText value="#{expedienteController.selected.claveFiscal}" title="C. Fiscal"/>
                             <button><a href="https://auth.afip.gob.ar/contribuyente_/login.xhtml" target="_blank">Clave Fiscal</a></button>
 
-                        </h:panelGrid> 
-                    </p:panel>    
-                    
+                        </h:panelGrid>
+                    </p:panel>
+
                     <p:panel  style="margin-bottom:2px">
- 
+
                     <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
-                            
+
                         <h:outputText value="Fecha de cobro:" style="font-weight: bold" />
                          <h:outputText value="#{expedienteController.selected.fechaDeCobro}" title="fecha de cobro">
                                 <f:convertDateTime pattern="dd/MM/yyyy" />
                          </h:outputText>
-                    
-                    </h:panelGrid> 
-                    
+
+                    </h:panelGrid>
+
                     <h:panelGrid columns="10" rendered="#{expedienteController.selected != null}">
-                        
+
                         <h:outputText value="Procedencia:" style="font-weight: bold" />
                         <h:outputText value="#{expedienteController.selected.procedencia}" title="procedencia"/>
-                    
+
                     </h:panelGrid>
                     </p:panel>
-                  </p:fieldset>  
+                  </p:fieldset>
                     <br></br>
                    <p:fieldset legend="Agregar Agenda" toggleable="true" toggleSpeed="500">
-                         
+
                         <p:panel  style="margin-bottom:2px">
 
                             <h:panelGrid columns="6" rendered="#{expedienteController.selected != null}">
 
                                 <p:outputLabel value="#{bundle.CreateAgendaLabel_fecha}" for="fecha" style="font-weight: bold" />
                                 <p:calendar mindate="today" disabledWeekends="true" id="fecha" pattern="dd/MM/yyyy" value="#{agendaController.selected.fecha}" title="#{bundle.EditAgendaTitle_fecha}" showOn="button"/>
-                             </h:panelGrid> 
-                            
+                             </h:panelGrid>
+
                             <h:panelGrid columns="6" rendered="#{expedienteController.selected != null}">
                                 <p:outputLabel value="Descripción sugerida:" for="descripcionSugerida" style="font-weight: bold" />
                                 <p:selectOneMenu id="descripcionSugerida"
@@ -224,7 +236,7 @@
                                 <p:outputLabel value="Actividad:" for="descripcion" style="font-weight: bold" />
 
                                 <p:inputTextarea rows="5" cols="50" id="descripcion" value="#{agendaController.selected.descripcion}" title="#{bundle.CreateAgendaTitle_descripcion}" />
-                            </h:panelGrid>    
+                            </h:panelGrid>
                              <br></br>
 
                             <h:panelGrid columns="6" rendered="#{expedienteController.selected != null}" >
@@ -239,7 +251,7 @@
 
                         </p:panel>
                     </p:fieldset>
-                        
+
                     <p:commandButton value="#{bundle.Close}" onclick="ExpedienteJudicialViewDialog.hide()"/>
                 </h:panelGroup>
             </h:form>

--- a/web/expediente/fragments/laboralEdit.xhtml
+++ b/web/expediente/fragments/laboralEdit.xhtml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:p="http://primefaces.org/ui">
+    <div class="columna">
+        <p:outputLabel value="Datos laborales" style="font-weight: bold" />
+        <p:outputLabel value="Tipo de reclamo laboral:" for="laboralTipoReclamo" />
+        <p:selectOneMenu id="laboralTipoReclamo" value="#{expediente.laboralTipoReclamo}" editable="false">
+            <f:selectItem itemLabel=" -- Elige un tipo --" noSelectionOption="true" />
+            <f:selectItem itemLabel="Ordinario - Despido" itemValue="Ordinario - Despido" />
+            <f:selectItem itemLabel="Ordinario - Otros" itemValue="Ordinario - Otros" />
+            <f:selectItem itemLabel="PDA" itemValue="PDA" />
+            <f:selectItem itemLabel="Otro" itemValue="Otro" />
+        </p:selectOneMenu>
+        <p:outputLabel value="Detalle de siniestro/reclamo:" for="laboralDetalleReclamo" />
+        <p:inputTextarea id="laboralDetalleReclamo" value="#{expediente.laboralDetalleReclamo}" rows="3" cols="25" autoResize="false" />
+        <p:outputLabel value="Empleador:" for="laboralEmpleador" />
+        <p:inputText id="laboralEmpleador" value="#{expediente.laboralEmpleador}" />
+        <p:outputLabel value="CUIT:" for="laboralCuit" />
+        <p:inputText id="laboralCuit" value="#{expediente.laboralCuit}" />
+        <p:outputLabel value="Trabajo registrado:" for="laboralTrabajoRegistrado" />
+        <p:selectOneMenu id="laboralTrabajoRegistrado" value="#{expediente.laboralTrabajoRegistrado}" editable="false">
+            <f:selectItem itemLabel=" -- Elige una opción --" noSelectionOption="true" />
+            <f:selectItem itemLabel="Sí" itemValue="Sí" />
+            <f:selectItem itemLabel="No" itemValue="No" />
+        </p:selectOneMenu>
+        <p:outputLabel value="ART:" for="laboralArt" />
+        <p:inputText id="laboralArt" value="#{expediente.laboralArt}" />
+    </div>
+    <div class="columna">
+        <p:outputLabel value="Fecha de ingreso:" for="laboralFechaIngreso" />
+        <p:calendar id="laboralFechaIngreso" pattern="dd/MM/yyyy" value="#{expediente.laboralFechaIngreso}" showOn="button" />
+        <p:outputLabel value="Fecha de egreso:" for="laboralFechaEgreso" />
+        <p:calendar id="laboralFechaEgreso" pattern="dd/MM/yyyy" value="#{expediente.laboralFechaEgreso}" showOn="button" />
+        <p:outputLabel value="Descripción del puesto:" for="laboralDescripcionPuesto" />
+        <p:inputTextarea id="laboralDescripcionPuesto" value="#{expediente.laboralDescripcionPuesto}" rows="4" cols="25" autoResize="false" />
+        <p:outputLabel value="Jornada:" for="laboralJornada" />
+        <p:inputText id="laboralJornada" value="#{expediente.laboralJornada}" />
+        <p:outputLabel value="Salario:" for="laboralSalario" />
+        <p:inputText id="laboralSalario" value="#{expediente.laboralSalario}" />
+        <p:outputLabel value="CCT:" for="laboralCct" />
+        <p:inputText id="laboralCct" value="#{expediente.laboralCct}" />
+        <p:outputLabel value="Observaciones:" for="laboralObservaciones" />
+        <p:inputTextarea id="laboralObservaciones" value="#{expediente.laboralObservaciones}" rows="3" cols="25" autoResize="false" />
+        <p:outputLabel value="Superintendencia de Riesgo del Trabajo" style="font-weight: bold" />
+        <p:outputLabel value="Tipo de trámite:" for="laboralSrtTipoTramite" />
+        <p:inputText id="laboralSrtTipoTramite" value="#{expediente.laboralSrtTipoTramite}" />
+        <p:outputLabel value="Expediente SRT:" for="laboralSrtExpediente" />
+        <p:inputText id="laboralSrtExpediente" value="#{expediente.laboralSrtExpediente}" />
+    </div>
+</ui:composition>

--- a/web/expediente/fragments/laboralView.xhtml
+++ b/web/expediente/fragments/laboralView.xhtml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:panelGrid columns="4" cellspacing="5">
+        <h:outputText value="Tipo de reclamo laboral:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralTipoReclamo}" />
+        <h:outputText value="Detalle de siniestro/reclamo:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralDetalleReclamo}" />
+        <h:outputText value="Empleador:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralEmpleador}" />
+        <h:outputText value="CUIT:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralCuit}" />
+        <h:outputText value="Trabajo registrado:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralTrabajoRegistrado}" />
+        <h:outputText value="ART:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralArt}" />
+        <h:outputText value="Fecha de ingreso:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralFechaIngreso}"><f:convertDateTime pattern="dd/MM/yyyy" /></h:outputText>
+        <h:outputText value="Fecha de egreso:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralFechaEgreso}"><f:convertDateTime pattern="dd/MM/yyyy" /></h:outputText>
+        <h:outputText value="Descripción del puesto:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralDescripcionPuesto}" />
+        <h:outputText value="Jornada:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralJornada}" />
+        <h:outputText value="Salario:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralSalario}" />
+        <h:outputText value="CCT:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralCct}" />
+        <h:outputText value="Observaciones laborales:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralObservaciones}" />
+        <h:outputText value="SRT - Tipo de trámite:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralSrtTipoTramite}" />
+        <h:outputText value="SRT - Expediente:" style="font-weight: bold" /><h:outputText value="#{expediente.laboralSrtExpediente}" />
+    </h:panelGrid>
+</ui:composition>

--- a/web/expediente/viewEnAgenda/Edit.xhtml
+++ b/web/expediente/viewEnAgenda/Edit.xhtml
@@ -41,16 +41,16 @@
 
 
 
-                        <p:commandButton value="Cerrar" 
+                        <p:commandButton value="Cerrar"
 
                                          styleClass="boton-cancelar"
-                                         onclick="PF('ExpedienteViewDesdeAgendaDialog').hide();" 
+                                         onclick="PF('ExpedienteViewDesdeAgendaDialog').hide();"
                                          />
                     </f:facet>
 
                 </p:toolbar>
 
-                <div style="float: left;width: 100%;">   
+                <div style="float: left;width: 100%;">
 
                     <p:tabView id="tabViewEditExpAdm" orientation="left" styleClass="tabdatospersonales" >
                         <h:panelGroup id="display">
@@ -60,13 +60,13 @@
                         <p:tab >
                             <f:facet name="title">
 
-                                <h:outputText id="iconoDatos" 
-                                              styleClass="fa fa-user" 
+                                <h:outputText id="iconoDatos"
+                                              styleClass="fa fa-user"
                                               style="font-size: 1.2rem; cursor: pointer;" />
                                 <p:tooltip for="iconoDatos" value="Datos Personales" />
 
                             </f:facet>
-                            <div class="datospersonales"> 
+                            <div class="datospersonales">
                                 <div class="columna">
                                     <p:outputLabel value="#{bundle.CreateExpedienteLabel_apellido}" for="apellido"  />
                                     <p:inputText id="apellido" value="#{expedienteController.selectedParaVerExp.apellido}" title="#{bundle.CreateExpedienteTitle_apellido}" />
@@ -89,7 +89,7 @@
                                     </p:calendar>
 
                                     <p:outputLabel value="#{bundle.EditExpedienteLabel_edad}" for="edad"  class=""/>
-                                    <p:inputText id="edad"  value="#{expedienteController.selectedParaVerExp.edad}" 
+                                    <p:inputText id="edad"  value="#{expedienteController.selectedParaVerExp.edad}"
                                                  title="#{bundle.EditExpedienteTitle_edad}"  readonly="true"/> <!-- AQUI SE CAMBIO EL LABEL POR INPUT QUE NO SE PUEDA EDITAR PARA QUE QUEDE MAS ESTETICO -->
 
                                     <p:outputLabel value="#{bundle.CreateExpedienteLabel_sexo}" for="sexo" />
@@ -137,11 +137,11 @@
                                         <p:outputLabel value="Hijos por los que percibió AUH:" rendered="#{expedienteController.selectedParaVerExp.sexo == 'Femenino'}" />
                                         <p:inputText rendered="#{expedienteController.selectedParaVerExp.sexo == 'Femenino'}" value="#{expedienteController.selectedParaVerExp.cantidadDeHijosPercibioAuh}" />
                                     </h:panelGrid>
-                                </div> 
+                                </div>
 
                                 <div class="columna">
 
-                                    <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono"  />    
+                                    <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono"  />
 
                                     <div class="telefonoinput">
                                         <p:inputText id="telefono" value="#{expedienteController.selectedParaVerExp.telefono}" title="#{bundle.CreateExpedienteTitle_telefono}" />
@@ -152,7 +152,7 @@
                                             <img src="../faces/resources/images/whatsapp.png" ></img>
                                         </a>
                                     </div>
-                                    <p:outputLabel value="Teléfono Auxiliar" for="telefonoAuxiliar"  />            
+                                    <p:outputLabel value="Teléfono Auxiliar" for="telefonoAuxiliar"  />
                                     <p:inputTextarea    id="telefonoAuxiliar" value="#{expedienteController.selectedParaVerExp.telefonoAuxiliar}" cols="22" title="Telèfono Auxiliar" style="height: 21px;"/>
                                     <p:outputLabel value="Email:" for="email"  />
                                     <p:inputText id="email" value="#{expedienteController.selectedParaVerExp.email}" title="Email" />
@@ -198,13 +198,13 @@
                                     <p:selectOneMenu   id="inscripcionAut" value="#{expedienteController.selectedParaVerExp.inscripcionAut}" >
                                         <f:selectItem itemLabel="SI" itemValue="SI" />
                                         <f:selectItem itemLabel="NO" itemValue="NO" />
-                                    </p:selectOneMenu>   
+                                    </p:selectOneMenu>
 
                                     <p:outputLabel  value="Posible Reclamo ART: " for="reclamoArt" />
                                     <p:selectOneMenu id="reclamoArt" value="#{expedienteController.selectedParaVerExp.reclamoArt}" >
                                         <f:selectItem itemLabel="SI" itemValue="SI" />
                                         <f:selectItem itemLabel="NO" itemValue="NO" />
-                                    </p:selectOneMenu>   
+                                    </p:selectOneMenu>
 
                                     <p:outputLabel value="Expediente físico:" for="fisico" style="font-weight: bold" />
                                     <p:selectOneMenu id="fisico" value="#{expedienteController.selectedParaVerExp.fisico}">
@@ -231,7 +231,7 @@
                                         <f:selectItem itemLabel="NO" itemValue="NO" />
                                         <f:selectItem itemLabel="SI" itemValue="SI" />
                                         <p:ajax update="inputAportes" />
-                                    </p:selectOneMenu>   
+                                    </p:selectOneMenu>
 
                                     <h:panelGrid id="inputAportes" columns="1"
                                                  cellpadding="0"
@@ -245,7 +245,7 @@
                                             <f:selectItem itemLabel="NO" itemValue="NO" />
                                             <f:selectItem itemLabel="SI" itemValue="SI" />
                                             <p:ajax update="inputObraSocial" />
-                                        </p:selectOneMenu>   
+                                        </p:selectOneMenu>
 
                                     </h:panelGrid  >
                                     <h:panelGrid id="inputObraSocial" columns="1"
@@ -257,9 +257,9 @@
                                     </h:panelGrid>
 
                                 </div>
-                                <div  class="columna"> 
+                                <div  class="columna">
 
-                                    <div class="roww1"> 
+                                    <div class="roww1">
                                         <div class="imagenentidad">
                                             <a href="https://servicioscorp.anses.gob.ar/clavelogon/logon.aspx?system=miansesv2" target="_blank" >
                                                 <img src="../faces/resources/images/anses.png" ></img>
@@ -273,7 +273,7 @@
 
                                         </div>
                                     </div>
-                                    <div class="roww1"> 
+                                    <div class="roww1">
                                         <div class="arca" >
                                             <a href="https://auth.afip.gob.ar/contribuyente_/login.xhtml" target="_blank" >
                                                 <img src="../faces/resources/images/arca.jpg"  ></img>
@@ -308,8 +308,8 @@
                         <p:tab >
                             <f:facet name="title">
 
-                                <h:outputText id="iconoEXP"  
-                                              styleClass="fa fa-folder" 
+                                <h:outputText id="iconoEXP"
+                                              styleClass="fa fa-folder"
                                               style="font-size: 1.2rem; cursor: pointer;" />
                                 <p:tooltip for="iconoEXP" value="Datos del expediente" />
 
@@ -338,13 +338,24 @@
                                     <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
+                                    <p:ajax update="@form" />
                                     </p:selectOneMenu>
 
 
 
 
 
-                                    <p:outputLabel value="Equipo:" for="equipo"  />
+
+
+                                    <h:panelGroup id="laboralPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteParaVerSeleccionadoLaboralJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/laboralEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selectedParaVerExp}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
+<p:outputLabel value="Equipo:" for="equipo"  />
                                     <p:selectOneMenu id="equipo" editable="false" effect="fold" value="#{expedienteController.selectedParaVerExp.equipo}">
                                         <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                         <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
@@ -392,7 +403,7 @@
                                                                                                                                                                expedienteController.selectedParaVerExp.telefono,
                                                                                                                                                                expedienteController.selectedParaVerExp.cuit,
                                                                                                                                                                expedienteController.selectedParaVerExp.fechaDeNacimiento,
-                                                                                                                                                               expedienteController.selectedParaVerExp.edad, 
+                                                                                                                                                               expedienteController.selectedParaVerExp.edad,
                                                                                                                                                                expedienteController.selectedParaVerExp.cobraBeneficio,
                                                                                                                                                                expedienteController.selectedParaVerExp.tipoDeBeneficio,
                                                                                                                                                                expedienteController.selectedParaVerExp.aportes,
@@ -419,10 +430,10 @@
 
                                 <div style="text-align: right ; padding-bottom: 20px ;display: grid;" >
                                     <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
-                                                      actionListener="#{comunicacionController.prepareCreateComunicacion(expedienteController.selectedParaVerExp.orden)}"  value="crear comunicación" 
+                                                      actionListener="#{comunicacionController.prepareCreateComunicacion(expedienteController.selectedParaVerExp.orden)}"  value="crear comunicación"
                                                       resetValues="true"
                                                       update=":ComunicacionCreateFormExpAdmDesdeAgenda" oncomplete="PF('ComunicacionCreateDialogExpAdmDesdeAgenda').show()" />
-                                </div>      
+                                </div>
 
                                 <p:dataTable id="datalist4"
                                              value="#{expedienteController.verComunicacionesPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
@@ -433,11 +444,11 @@
                                              rows="10"
                                              widgetVar="comunicacionesTable2"
                                              rowsPerPageTemplate="10,20,50"
-                                             emptyMessage="no hay comunicaciones agregadas" 
-                                             rendered="true"  
+                                             emptyMessage="no hay comunicaciones agregadas"
+                                             rendered="true"
                                              style="display: table;"
                                              styleClass="tabla-tailwind"
-                                             sortBy="#{item.fecha}" sortOrder="descending" 
+                                             sortBy="#{item.fecha}" sortOrder="descending"
                                              >
 
                                     <p:ajax event="rowSelect"  />
@@ -459,7 +470,7 @@
 
                                     <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                         <div style="display:flex;justify-content: center">
-                                            <h:outputText id="responsableicon"  
+                                            <h:outputText id="responsableicon"
                                                           value="#{expedienteController.getIniciales(item.responsable)}"
                                                           style="color:white; border-radius:50%; width:28px; height:28px;
                                                           display:flex; align-items:center; justify-content:center;
@@ -483,16 +494,16 @@
                                         <p:commandButton class="linea btnDelete" update=":growl,datalist4" oncomplete="PF('expedientesTable').clearFilters()" actionListener="#{comunicacionController.destroy}"  icon="ui-icon-trash" title="Eliminar">
                                             <f:setPropertyActionListener value="#{item}" target="#{comunicacionController.selected}" />
                                             <p:confirm header="Confirmación" message="¿Estas seguro?"  icon="ui-icon-alert"/>
-                                        </p:commandButton> 
+                                        </p:commandButton>
 
-                                    </p:column>    
+                                    </p:column>
 
                                 </p:dataTable>
 
                                 <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                     <p:commandButton update=":ExpedienteListForm" value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;" />
                                     <p:commandButton update=":ExpedienteListForm" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;" />
-                                </p:confirmDialog> 
+                                </p:confirmDialog>
 
                             </div>
 
@@ -504,13 +515,13 @@
                                 <p:tooltip for="iconoAgendas" value="Agendas y Turnos" />
                             </f:facet>
 
-                            <div class="agendasyturnos"> 
+                            <div class="agendasyturnos">
 
-                                <p:commandButton 
-                                    id="createButton" 
-                                    class="boton-guardar" 
+                                <p:commandButton
+                                    id="createButton"
+                                    class="boton-guardar"
                                     value="Crear Agenda"
-                                    actionListener="#{agendaController.prepareCreate}"  
+                                    actionListener="#{agendaController.prepareCreate}"
                                     process="@this"
                                     update=":ExpedienteViewFormParaAgendadesdeagenda"
                                     oncomplete="PF('ExpedienteViewDialogParaAgendadesdeagenda').show();" />
@@ -518,17 +529,17 @@
                                 <p:commandButton id="createButtonTurno"
                                                  class="boton-sistema" style="margin-right: 10px !important;
                                                  margin-left: 10px;"
-                                                 value="Crear Turno" 
+                                                 value="Crear Turno"
                                                  actionListener="#{turnoController.prepareCreate}"
                                                  update=":ExpedienteViewFormParaTurnodesdeagenda"
                                                  oncomplete="PF('ExpedienteViewDialogParaTurnodesdeagenda').show(); " />
-                              
+
 
 
 
 
                                  <p:fieldset class="tablashistorial" legend="AGENDAS ANTERIORES" toggleable="true"  collapsed="true" toggleSpeed="500">
-                                    <p:dataTable id="datalist3" 
+                                    <p:dataTable id="datalist3"
                                                  value="#{expedienteController.verAgendasPasadasPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
                                                  var="item"
                                                  selectionMode="single"
@@ -538,7 +549,7 @@
                                                  rendered="true"
                                                  rows="10"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay agendas Pasadas agregadas" 
+                                                 emptyMessage="no hay agendas Pasadas agregadas"
                                                  filteredValue="#{expedienteController.filteredAgendasAnteriores}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -554,7 +565,7 @@
                                         </p:column>
                                         <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -576,42 +587,42 @@
 
                                         <p:column  style="text-align: center; width:15%; " headerText="Acciones">
 
-                                     
+
 
                                             <p:commandButton class="linea btnKeyGreen"
-                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalist3" 
+                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalist3"
                                                              actionListener="#{agendaController.marcarComoRealizadaSiAgendaPasada()}"
                                                              icon=" ui-icon-check" title="Marcar como realizado si">
                                                 <f:setPropertyActionListener value="#{item}" target="#{agendaController.selectedAgendaPasada}" />
                                             </p:commandButton>
 
                                             <p:commandButton class="linea btnDelete"
-                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalist3, message3" 
+                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalist3, message3"
                                                              actionListener="#{agendaController.destroyAgendaPasada()}"  icon="ui-icon-trash" title="Eliminar">
                                                 <f:setPropertyActionListener value="#{item}" target="#{agendaController.selectedAgendaPasada}" />
                                                 <p:confirm header="Confirmación" message="¿Estas seguro?" icon="ui-icon-alert"/>
-                                            </p:commandButton> 
+                                            </p:commandButton>
 
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                                 <p:commandButton   update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalist3"  value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
 
                                     </p:dataTable>
                                 </p:fieldset>
  <p:fieldset class="tablashistorial" legend="TURNOS ANTERIORES" toggleable="true"  collapsed="true" toggleSpeed="500">
-                                    <p:dataTable id="datalistTurnosAnteriores" 
+                                    <p:dataTable id="datalistTurnosAnteriores"
                                                  value="#{expedienteController.verTurnosPasadosPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
                                                  var="item"
                                                  selectionMode="single"
                                                  selection="#{turnoController.selectedTurnoPasado}"
                                                  rowKey="#{item.idTurno}"
-                                                 paginator="true"    
+                                                 paginator="true"
                                                  rendered="true"
                                                  rows="10"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay turnos Pasados agregados" 
+                                                 emptyMessage="no hay turnos Pasados agregados"
                                                  filteredValue="#{expedienteController.filteredTurnosAnteriores}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -636,18 +647,18 @@
                                                     <f:selectItem itemLabel="Pendiente" itemValue="Pendiente" />
                                                 </p:selectOneMenu>
                                             </f:facet>
-                                            <div class="apilarelementos"> 
+                                            <div class="apilarelementos">
                                                 <h:outputText value="#{item.realizado eq 'Si' ? 'Realizado' : (item.realizado eq 'Pendiente' ? 'Pendiente' : 'Por Atender')}" styleClass="estadofinalizado#{item.realizado}" />
 
                                                 <h:outputText  value="#{item.horaYDia}" styleClass="fechacolumna" >
                                                     <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
                                                 </h:outputText>
-                                            </div> 
+                                            </div>
                                         </p:column>
                                         <p:column filterBy="#{item.responsable}" headerText="Responsable"  filterMatchMode="contains" style="width:10%" class="iconoturnorespondable" >
 
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -662,14 +673,14 @@
                                         <p:column  style="text-align: center; width: 10%" headerText="Acciones">
 
                                             <p:commandButton class="linea btnKeyGreen"
-                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosAnteriores" 
+                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosAnteriores"
                                                              actionListener="#{turnoController.marcarComoRealizadoSiTurnoPasado()}"
                                                              icon=" ui-icon-check" title="Marcar como realizado si">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoPasado}" />
                                             </p:commandButton>
 
                                             <p:commandButton class="linea btnDelete"
-                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosAnteriores, message3" 
+                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosAnteriores, message3"
                                                              actionListener="#{turnoController.destroyTurnoPasado()}"  icon="ui-icon-trash" title="Eliminar">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoPasado}" />
                                                 <p:confirm header="Confirmación" message="¿Estas seguro?" icon="ui-icon-alert"/>
@@ -678,15 +689,15 @@
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                                 <p:commandButton   update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosAnteriores"  value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
 
                                     </p:dataTable>
                                 </p:fieldset>
                          <p:fieldset class="tablashistorial" legend="AGENDAS FUTURAS" toggleable="true"  collapsed="true" toggleSpeed="500">
 
-                                    <p:dataTable id="datalist2" 
-                                                 value="#{expedienteController.verAgendasFuturasPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}" 
+                                    <p:dataTable id="datalist2"
+                                                 value="#{expedienteController.verAgendasFuturasPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
                                                  var="item"
                                                  selectionMode="single"
                                                  selection="#{agendaController.selectedAgendaFutura}"
@@ -695,7 +706,7 @@
                                                  rows="10"
                                                  rendered="true"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay agendas futuras agregadas" 
+                                                 emptyMessage="no hay agendas futuras agregadas"
                                                  filteredValue="#{expedienteController.filteredAgendasFuturas}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -713,7 +724,7 @@
                                         </p:column>
                                         <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -750,18 +761,18 @@
                                             </p:commandButton>
 
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
-                                                <p:commandButton   update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalist2" 
+                                                <p:commandButton   update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalist2"
                                                                    value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
                                     </p:dataTable>
                                 </p:fieldset>
 
                                <p:fieldset class="tablashistorial" legend="TURNOS FUTUROS" toggleable="true"  collapsed="true" toggleSpeed="500">
 
-                                    <p:dataTable id="datalistTurnosFuturos" 
-                                                 value="#{expedienteController.verTurnosFuturosPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}" 
+                                    <p:dataTable id="datalistTurnosFuturos"
+                                                 value="#{expedienteController.verTurnosFuturosPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
                                                  var="item"
                                                  selectionMode="single"
                                                  selection="#{turnoController.selectedTurnoFuturo}"
@@ -770,7 +781,7 @@
                                                  rows="10"
                                                  rendered="true"
                                                  rowsPerPageTemplate="10,20,40,50"
-                                                 emptyMessage="no hay turnos futuros agregados" 
+                                                 emptyMessage="no hay turnos futuros agregados"
                                                  filteredValue="#{expedienteController.filteredTurnosFuturos}"
                                                  style="display: table;padding: 20px"
                                                  styleClass="tabla-tailwind"
@@ -796,18 +807,18 @@
                                                     <f:selectItem itemLabel="Pendiente" itemValue="Pendiente" />
                                                 </p:selectOneMenu>
                                             </f:facet>
-                                            <div class="apilarelementos"> 
+                                            <div class="apilarelementos">
                                                 <h:outputText value="#{item.realizado eq 'Si' ? 'Realizado' : (item.realizado eq 'Pendiente' ? 'Pendiente' : 'Por Atender')}" styleClass="estadofinalizado#{item.realizado}" />
 
                                                 <h:outputText  value="#{item.horaYDia}" styleClass="fechacolumna" >
                                                     <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
                                                 </h:outputText>
-                                            </div> 
+                                            </div>
                                         </p:column>
                                         <p:column filterBy="#{item.responsable}" headerText="Responsable"  filterMatchMode="contains" style="width:10%" class="iconoturnorespondable" >
 
                                             <div style="display:flex;justify-content: center">
-                                                <h:outputText id="responsableicon"  
+                                                <h:outputText id="responsableicon"
                                                               value="#{expedienteController.getIniciales(item.responsable)}"
                                                               style="color:white; border-radius:50%; width:28px; height:28px;
                                                               display:flex; align-items:center; justify-content:center;
@@ -821,14 +832,14 @@
                                         <p:column  style="text-align: center; width: 10%" headerText="Acciones">
 
                                             <p:commandButton class="linea btnKeyGreen"
-                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosFuturos" 
+                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosFuturos"
                                                              actionListener="#{turnoController.marcarComoRealizadoSiTurnoFuturo()}"
                                                              icon=" ui-icon-check" title="Marcar como realizado si">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoFuturo}" />
                                             </p:commandButton>
 
                                             <p:commandButton class="linea btnDelete"
-                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosFuturos, message4" 
+                                                             update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosFuturos, message4"
                                                              actionListener="#{turnoController.destroyTurnoFuturo()}"  icon="ui-icon-trash" title="Eliminar">
                                                 <f:setPropertyActionListener value="#{item}" target="#{turnoController.selectedTurnoFuturo}" />
                                                 <p:confirm header="Confirmación" message="¿Estas seguro?" icon="ui-icon-alert"/>
@@ -837,7 +848,7 @@
                                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                                 <p:commandButton   update=":ExpedienteViewDesdeAgendaForm:tabViewEditExpAdm:datalistTurnosFuturos"  value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                                 <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                            </p:confirmDialog> 
+                                            </p:confirmDialog>
                                         </p:column>
 
                                     </p:dataTable>
@@ -880,7 +891,7 @@
                             </div>
                             <div class="editordetexto">
                                 <p:editor  value="#{expedienteController.selectedParaVerExp.tablaDeHonorariosYGastos}"></p:editor>
-                            </div>  
+                            </div>
                         </p:tab>
                         <p:tab >
                             <f:facet name="title">
@@ -892,7 +903,7 @@
                             <div class="comunicaciones">
 
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar" style="margin-bottom: 20px;"
-                                                  actionListener="#{situacionPrevisionalController.prepareCreateSituacionPrevisional(expedienteController.selectedParaVerExp.orden)}"  value="crear situación previsional" 
+                                                  actionListener="#{situacionPrevisionalController.prepareCreateSituacionPrevisional(expedienteController.selectedParaVerExp.orden)}"  value="crear situación previsional"
                                                   update=":SituacionPrevisionalCreateFormExpAdmDesdeAgenda" oncomplete="PF('SituacionPrevisionalCreateDialogExpAdmDesdeAgenda').show()" />
                                 <p:dataTable id="datalistSituacionPrevisional"
                                              value="#{situacionPrevisionalController.verSituacionPrevisionalesPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
@@ -904,7 +915,7 @@
                                              rows="10"
                                              rendered="true"
                                              rowsPerPageTemplate="10,20,50"
-                                             emptyMessage="no hay situaciones previsionales agregadas" 
+                                             emptyMessage="no hay situaciones previsionales agregadas"
                                              style="display: table;padding: 20px"
                                              styleClass="tabla-tailwind"
                                              >
@@ -947,7 +958,7 @@
 
                                         <p:commandButton class="linea btnDelete" update=":growl,datalistSituacionPrevisional" actionListener="#{situacionPrevisionalController.destroy}"  icon="ui-icon-trash" title="Eliminar">
                                             <f:setPropertyActionListener value="#{item}" target="#{situacionPrevisionalController.selected}" />
-                                        </p:commandButton> 
+                                        </p:commandButton>
 
                                     </p:column>
 
@@ -961,7 +972,7 @@
                                         <p:ajax update="panelCodigoEvaluacionSocioeconomica"/>
                                     </p:selectBooleanCheckbox>
 
-                                    <h:outputLabel for="btnCompraLey24476" 
+                                    <h:outputLabel for="btnCompraLey24476"
                                                    value="Compra aportes con moratoria Ley 24.476" />
                                 </div>
 
@@ -1007,15 +1018,15 @@
                                                      autoResize="true"
                                                      style="margin-left:10px;margin-right: 10px !important;"
                                                      rows="20"
-                                                     value="#{empty situacionPrevisionalController.totalTiempoConAportes 
-                                                              ? '' 
+                                                     value="#{empty situacionPrevisionalController.totalTiempoConAportes
+                                                              ? ''
                                                               : situacionPrevisionalController.totalTiempoConAportes.trim()}" />
                                 </h:panelGroup>
 
 
                             </div>
                         </p:tab>
-                    </p:tabView>      
+                    </p:tabView>
                 </div>
             </h:form>
 

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -33,14 +33,14 @@
                         <h:outputLink value="http://scw.pjn.gov.ar/scw/home.seam" target="_blank"
                                       styleClass="boton-sistema"
                                       style="background: #32424A !important; margin-right: 10px;"
-                                      rendered="#{expedienteController.selectedParaVerExp.equipo ne null 
+                                      rendered="#{expedienteController.selectedParaVerExp.equipo ne null
                                                   and expedienteController.selectedParaVerExp.equipo.contains('JUSTICIA FEDERAL')}">
                             Justicia Federal
                         </h:outputLink>
 
                         <h:outputLink value="https://www.justiciacordoba.gob.ar/JusticiaCordoba/extranet.aspx" target="_blank"
                                       styleClass="boton-sistema"
-                                      rendered="#{expedienteController.selectedParaVerExp.equipo ne null 
+                                      rendered="#{expedienteController.selectedParaVerExp.equipo ne null
                                                   and expedienteController.selectedParaVerExp.equipo.contains('JUSTICIA PROVINCIAL')}">
                             Justicia Provincial
                         </h:outputLink>
@@ -48,10 +48,10 @@
                                           update=":TurnoListForm:datalist" oncomplete="handleSubmit(args, 'ExpedienteJudicialViewDesdeAgendaDialog');"/>-->
 
 
-                        <p:commandButton value="Cerrar" 
+                        <p:commandButton value="Cerrar"
                                          style="margin-left: 10px;"
                                          styleClass="boton-cancelar"
-                                         onclick="PF('ExpedienteJudicialViewDesdeAgendaDialog').hide();" 
+                                         onclick="PF('ExpedienteJudicialViewDesdeAgendaDialog').hide();"
                                          />
                     </f:facet>
 
@@ -67,8 +67,8 @@
                     <p:tab >
                         <f:facet name="title">
 
-                            <h:outputText id="iconoDatos" value="" 
-                                          styleClass="fa fa-user" 
+                            <h:outputText id="iconoDatos" value=""
+                                          styleClass="fa fa-user"
                                           style="font-size: 1.2rem; cursor: pointer;" />
                             <p:tooltip for="iconoDatos" value="Datos Personales" />
 
@@ -98,7 +98,7 @@
 
 
                                 <p:outputLabel value="#{bundle.EditExpedienteLabel_edad}" for="edad"  class=""/>
-                                <p:inputText id="edad"  value="#{expedienteController.selectedParaVerExp.edad}" 
+                                <p:inputText id="edad"  value="#{expedienteController.selectedParaVerExp.edad}"
                                              title="#{bundle.EditExpedienteTitle_edad}"  readonly="true"/> <!-- AQUI SE CAMBIO EL LABEL POR INPUT QUE NO SE PUEDA EDITAR PARA QUE QUEDE MAS ESTETICO -->
 
                                 <p:outputLabel  value="#{bundle.EditExpedienteLabel_fechaDeNacimiento}" for="fechaDeNacimiento"  />
@@ -155,7 +155,7 @@
                             </div>
                             <div class="columna">
 
-                                <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono"  />    
+                                <p:outputLabel value="#{bundle.CreateExpedienteLabel_telefono}" for="telefono"  />
 
                                 <div class="telefonoinput">
                                     <p:inputText  id="telefono" value="#{expedienteController.selectedParaVerExp.telefono}" style="" title="#{bundle.CreateExpedienteTitle_telefono}" />
@@ -211,13 +211,13 @@
                                 <p:selectOneMenu   id="inscripcionAut" value="#{expedienteController.selectedParaVerExp.inscripcionAut}" >
                                     <f:selectItem itemLabel="SI" itemValue="SI" />
                                     <f:selectItem itemLabel="NO" itemValue="NO" />
-                                </p:selectOneMenu>   
+                                </p:selectOneMenu>
 
                                 <p:outputLabel  value="Posible Reclamo ART: " for="reclamoArt" />
                                 <p:selectOneMenu id="reclamoArt" value="#{expedienteController.selectedParaVerExp.reclamoArt}" >
                                     <f:selectItem itemLabel="SI" itemValue="SI" />
                                     <f:selectItem itemLabel="NO" itemValue="NO" />
-                                </p:selectOneMenu>   
+                                </p:selectOneMenu>
 
                                 <p:outputLabel value="Expediente físico:" for="fisico" style="font-weight: bold" />
                                     <p:selectOneMenu id="fisico" value="#{expedienteController.selectedParaVerExp.fisico}">
@@ -244,7 +244,7 @@
                                     <f:selectItem itemLabel="NO" itemValue="NO" />
                                     <f:selectItem itemLabel="SI" itemValue="SI" />
                                     <p:ajax update="inputAportes" />
-                                </p:selectOneMenu>   
+                                </p:selectOneMenu>
 
                                 <h:panelGrid id="inputAportes" columns="1"
                                              cellpadding="0"
@@ -258,7 +258,7 @@
                                         <f:selectItem itemLabel="NO" itemValue="NO" />
                                         <f:selectItem itemLabel="SI" itemValue="SI" />
                                         <p:ajax update="inputObraSocial" />
-                                    </p:selectOneMenu>   
+                                    </p:selectOneMenu>
 
                                 </h:panelGrid  >
                                 <h:panelGrid id="inputObraSocial" columns="1"
@@ -272,8 +272,8 @@
                             </div>
 
                             <div class="columna">
-                                
-                                <div class="roww1"> 
+
+                                <div class="roww1">
                                     <div class="imagenentidad">
                                         <a href="https://servicioscorp.anses.gob.ar/clavelogon/logon.aspx?system=miansesv2" target="_blank" >
                                             <img src="../faces/resources/images/anses.png" ></img>
@@ -287,7 +287,7 @@
 
                                     </div>
                                 </div>
-                                <div class="roww1"> 
+                                <div class="roww1">
                                     <div class="arca" >
                                         <a href="https://auth.afip.gob.ar/contribuyente_/login.xhtml" target="_blank" >
                                             <img src="../faces/resources/images/arca.jpg"  ></img>
@@ -317,15 +317,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
+                        </div>
 
 
                     </p:tab>
                     <p:tab >
                         <f:facet name="title">
 
-                            <h:outputText id="iconoEXP" value="" 
-                                          styleClass="fa fa-folder" 
+                            <h:outputText id="iconoEXP" value=""
+                                          styleClass="fa fa-folder"
                                           style="font-size: 1.2rem; cursor: pointer;" />
                             <p:tooltip for="iconoEXP" value="Datos del expediente" />
 
@@ -360,7 +360,17 @@
                                     <p:ajax update="@form" />
                                     </p:selectOneMenu>
 
-                                <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
+
+
+                                <h:panelGroup id="laboralPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                    <h:panelGroup layout="block" rendered="#{expedienteController.expedienteParaVerSeleccionadoLaboralJusticiaProvincial}">
+                                        <ui:include src="/expediente/fragments/laboralEdit.xhtml">
+                                            <ui:param name="expediente" value="#{expedienteController.selectedParaVerExp}" />
+                                        </ui:include>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
+<p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
                                     <p:commandButton value="Si" type="button" styleClass="ui-confirmdialog-no" icon="pi pi-times" update=":ExpedienteJudicialViewDesdeAgendaForm:tabViewEditExpJudicialEditForm" />
                                 </p:confirmDialog>
                                 <p:outputLabel value="Equipo:" for="equipo"  />
@@ -423,6 +433,9 @@
 
                             </div>
                             <div class="columna">
+
+                                <p:outputLabel value="Categoría de juicio:" for="laboralCategoriaJuicio" rendered="#{expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}" />
+                                <p:inputText id="laboralCategoriaJuicio" value="#{expedienteController.selectedParaVerExp.laboralCategoriaJuicio}" rendered="#{expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}" />
 
                                 <p:outputLabel value="Nº de Expediente:" for="nroDeExpediente"  />
                                 <p:inputText id="nroDeExpediente" value="#{expedienteController.selectedParaVerExp.nroDeExpediente}" title="nroDeExpediente" />
@@ -494,7 +507,7 @@
                                                                                                                                                                expedienteController.selectedParaVerExp.telefono,
                                                                                                                                                                expedienteController.selectedParaVerExp.cuit,
                                                                                                                                                                expedienteController.selectedParaVerExp.fechaDeNacimiento,
-                                                                                                                                                               expedienteController.selectedParaVerExp.edad, 
+                                                                                                                                                               expedienteController.selectedParaVerExp.edad,
                                                                                                                                                                expedienteController.selectedParaVerExp.cobraBeneficio,
                                                                                                                                                                expedienteController.selectedParaVerExp.tipoDeBeneficio,
                                                                                                                                                                expedienteController.selectedParaVerExp.aportes,
@@ -513,7 +526,7 @@
                         </div>
 
                     </p:tab>
-                  
+
                     <p:tab id="tabComunicaciones" title="">
                         <f:facet name="title">
                             <h:outputText id="iconoComunicaciones" value="" styleClass="fa fa-comments" style="font-size: 1.2rem; cursor: pointer;" />
@@ -522,9 +535,9 @@
                         <div class="comunicaciones">
                             <div style="text-align: right ; padding-bottom: 20px ;display: grid;" >
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
-                                                  actionListener="#{comunicacionController.prepareCreateComunicacion(expedienteController.selectedParaVerExp.orden)}"  value="Crear Comunicación" 
+                                                  actionListener="#{comunicacionController.prepareCreateComunicacion(expedienteController.selectedParaVerExp.orden)}"  value="Crear Comunicación"
                                                   update=":ComunicacionCreatedesdeagendaForm" oncomplete="PF('ComunicacionCreatedesdeagendaDialog').show()" />
-                            </div>  
+                            </div>
                             <p:dataTable id="datalist3" value="#{expedienteController.verComunicacionesPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}" var="item"
                                          selectionMode="single" selection="#{comunicacionController.selected}"
                                          rowKey="#{item.idComunicacion}"
@@ -532,8 +545,8 @@
                                          rows="10"
                                          widgetVar="comunicacionesTable2"
                                          rowsPerPageTemplate="100,200,500"
-                                         emptyMessage="no hay comunicaciones agregadas" 
-                                         rendered="true" 
+                                         emptyMessage="no hay comunicaciones agregadas"
+                                         rendered="true"
                                          style="display: table;"
                                          styleClass="tabla-tailwind"
                                          sortBy="#{item.fecha}" sortOrder="descending"
@@ -555,7 +568,7 @@
 
                                 <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                     <div style="display:flex;justify-content: center">
-                                        <h:outputText id="responsableicon"  
+                                        <h:outputText id="responsableicon"
                                                       value="#{expedienteController.getIniciales(item.responsable)}"
                                                       style="color:white; border-radius:50%; width:28px; height:28px;
                                                       display:flex; align-items:center; justify-content:center;
@@ -577,17 +590,17 @@
                                     <p:commandButton class="linea btnDelete" update=":ExpedienteJudicialViewDesdeAgendaForm:tabViewEditExpJudicialEditForm:datalist3,:growl,"  actionListener="#{comunicacionController.destroy}"  icon="ui-icon-trash" title="Eliminar">
                                         <f:setPropertyActionListener value="#{item}" target="#{comunicacionController.selected}" />
                                         <p:confirm header="Confirmación" message="¿Estas seguro?"  icon="ui-icon-alert"/>
-                                    </p:commandButton> 
+                                    </p:commandButton>
 
-                                </p:column>   
+                                </p:column>
 
                             </p:dataTable>
                             <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                 <p:commandButton update=":ExpedienteListForm" value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;" />
                                 <p:commandButton update=":ExpedienteListForm" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;" />
-                            </p:confirmDialog> 
+                            </p:confirmDialog>
                         </div>
-                    </p:tab>       
+                    </p:tab>
 
 
                     <p:tab id="tabEventosDeCausasJudiciales" title="">
@@ -599,7 +612,7 @@
                             <div style="text-align: right ; padding-bottom: 20px ;display: grid;">
                                 <p:commandButton  class="botonEditarAgendaEsteBotonNoSirveMasPeroLoNecesitaLaUI boton-guardar"
                                                   actionListener="#{eventoDeCausasJudicialesController.prepareCreateEventoJudicial(expedienteController.selectedParaVerExp.orden, expedienteController.selectedParaVerExp.responsable)}"  value="Crear fecha Judicial "
-                                                  update=":EventoJudicialCreatedesdeagendaForm:display" 
+                                                  update=":EventoJudicialCreatedesdeagendaForm:display"
                                                   oncomplete="PF('EventoJudicialCreatedesdeagendaDialog').show()" />
                             </div>
                             <p:dataTable id="datalist6" value="#{expedienteController.verFechasJudicialesPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}" var="item"
@@ -609,8 +622,8 @@
                                          rows="10"
                                          widgetVar="eventosDeCausasJudicialesTable2"
                                          rowsPerPageTemplate="100,200,500"
-                                         emptyMessage="no hay eventos de causas judiciales agregadas" 
-                                         rendered="true"  
+                                         emptyMessage="no hay eventos de causas judiciales agregadas"
+                                         rendered="true"
                                          style="display: table;"
                                          styleClass="tabla-tailwind"
                                          >
@@ -640,17 +653,17 @@
                                         <f:setPropertyActionListener value="#{item}" target="#{eventoDeCausasJudicialesController.selected}" />
                                     </p:commandButton>
 
-                                    <p:commandButton class="linea btnDelete" 
+                                    <p:commandButton class="linea btnDelete"
                                                      update=":growl, :ExpedienteJudicialViewDesdeAgendaForm:tabViewEditExpJudicialEditForm:datalist6"
 
-                                                     actionListener="#{eventoDeCausasJudicialesController.destroy}"  
+                                                     actionListener="#{eventoDeCausasJudicialesController.destroy}"
                                                      icon="ui-icon-trash"
                                                      title="Eliminar">
                                         <f:setPropertyActionListener value="#{item}" target="#{eventoDeCausasJudicialesController.selected}" />
                                         <p:confirm header="Confirmación" message="¿Estas seguro?"  icon="ui-icon-alert"/>
-                                    </p:commandButton> 
+                                    </p:commandButton>
 
-                                </p:column>    
+                                </p:column>
 
                             </p:dataTable>
 
@@ -659,7 +672,7 @@
                         <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                             <p:commandButton update=":ExpedienteListForm" value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;" />
                             <p:commandButton update=":ExpedienteListForm" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;" />
-                        </p:confirmDialog> 
+                        </p:confirmDialog>
 
                     </p:tab>
 
@@ -671,11 +684,11 @@
 
 
                         <div class="agendasyturnos">
-                            <p:commandButton 
-                                id="createButton" 
-                                class="boton-guardar" 
+                            <p:commandButton
+                                id="createButton"
+                                class="boton-guardar"
                                 value="Crear Agenda"
-                                actionListener="#{agendaController.prepareCreate}"  
+                                actionListener="#{agendaController.prepareCreate}"
                                 process="@this"
                                 update=":ExpedienteViewFormParaAgendadesdeagenda"
                                 oncomplete="PF('ExpedienteViewDialogParaAgendadesdeagenda').show();" />
@@ -683,13 +696,13 @@
                             <p:commandButton id="createButtonTurno"
                                              class="boton-sistema" style="margin-right: 10px !important;
                                              margin-left: 10px;"
-                                             value="Crear Turno" 
+                                             value="Crear Turno"
                                              actionListener="#{turnoController.prepareCreate}"
                                              update=":ExpedienteViewFormParaTurnodesdeagenda"
                                              oncomplete="PF('ExpedienteViewDialogParaTurnodesdeagenda').show(); " />
 
 
-                            <p:fieldset legend="Agendas Anteriores" toggleable="true"  collapsed="true" toggleSpeed="500" class="tablashistorial">                                <!--Agendas Anteriores--> 
+                            <p:fieldset legend="Agendas Anteriores" toggleable="true"  collapsed="true" toggleSpeed="500" class="tablashistorial">                                <!--Agendas Anteriores-->
                                 <p:dataTable id="datalist4"
                                              value="#{expedienteController.verAgendasPasadasPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
                                              var="item"
@@ -723,7 +736,7 @@
                                     </p:column>
                                    <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                         <div style="display:flex;justify-content: center">
-                                            <h:outputText id="responsableicon"  
+                                            <h:outputText id="responsableicon"
                                                           value="#{expedienteController.getIniciales(item.responsable)}"
                                                           style="color:white; border-radius:50%; width:28px; height:28px;
                                                           display:flex; align-items:center; justify-content:center;
@@ -767,12 +780,12 @@
                                         <p:confirmDialog  global="true" showEffect="fade" hideEffect="fade">
                                             <p:commandButton  update=":tabViewEditExpJudicialEditForm:datalist4"  value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                             <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                        </p:confirmDialog> 
+                                        </p:confirmDialog>
                                     </p:column>
 
                                 </p:dataTable>
                             </p:fieldset>
-                            <p:fieldset legend="Turnos Anteriores" toggleable="true"  collapsed="true" toggleSpeed="500" class="tablashistorial">                          <!--Turnos Anteriores--> 
+                            <p:fieldset legend="Turnos Anteriores" toggleable="true"  collapsed="true" toggleSpeed="500" class="tablashistorial">                          <!--Turnos Anteriores-->
                                 <p:dataTable id="datalistTurnosAnteriores"
                                              widgetVar="tablaTurnosAnteriores"
                                              value="#{expedienteController.verTurnosPasadosPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
@@ -815,13 +828,13 @@
                                                 <f:selectItem itemLabel="Pendiente" itemValue="Pendiente" />
                                             </p:selectOneMenu>
                                         </f:facet>
-                                        <div class="apilarelementos"> 
+                                        <div class="apilarelementos">
                                             <h:outputText value="#{item.realizado eq 'Si' ? 'Realizado' : (item.realizado eq 'Pendiente' ? 'Pendiente' : 'Por Atender')}" styleClass="estadofinalizado#{item.realizado}" />
 
                                             <h:outputText  value="#{item.horaYDia}" styleClass="fechacolumna" >
                                                 <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
                                             </h:outputText>
-                                        </div> 
+                                        </div>
                                     </p:column>
                                       <p:column filterBy="#{item.responsable}" headerText="Responsable"  filterMatchMode="contains" style="width:10%" class="iconoturnorespondable" >
 
@@ -888,7 +901,7 @@
                                     </p:column>
                                     <p:column  headerText="Responsable"  class="iconoturnorespondable"  >
                                         <div style="display:flex;justify-content: center">
-                                            <h:outputText id="responsableicon"  
+                                            <h:outputText id="responsableicon"
                                                           value="#{expedienteController.getIniciales(item.responsable)}"
                                                           style="color:white; border-radius:50%; width:28px; height:28px;
                                                           display:flex; align-items:center; justify-content:center;
@@ -936,14 +949,14 @@
                                             <p:commandButton  update=":ExpedienteJudicialViewDesdeAgendaForm:tabViewEditExpJudicialEditForm:datalist5"
                                                               value="Si" type="button" styleClass="ui-confirmdialog-yes ui-state-default" icon="ui-icon-check" style="color: black;"/>
                                             <p:commandButton update="@all" value="No" type="button" styleClass="ui-confirmdialog-no ui-state-error-text" icon="ui-icon-close" style="color: black;"/>
-                                        </p:confirmDialog> 
+                                        </p:confirmDialog>
                                     </p:column>
 
                                 </p:dataTable>
                             </p:fieldset>
                             <p:fieldset legend="Turnos Futuros" toggleable="true"  collapsed="true" toggleSpeed="500" class="tablashistorial">                            <!--                                Turnos Futuros -->
                                 <p:dataTable id="tablaTurnosFuturos"
-                                             widgetVar="tablaTurnosFuturos"    
+                                             widgetVar="tablaTurnosFuturos"
                                              value="#{expedienteController.verTurnosFuturosPorNroDeOrden(expedienteController.selectedParaVerExp.orden)}"
                                              var="item"
                                              selectionMode="single"
@@ -963,7 +976,7 @@
                                     <p:ajax event="rowSelect"  />
                                     <p:ajax event="rowUnselect" />
                                     <p:growl life="2500" id="message4" showDetail="true" />
-                                
+
                                     <p:column style="text-align: start !important; width: 70%">
                                         <f:facet name="header">
                                             <h:outputText value="Descripción"/>
@@ -982,18 +995,18 @@
                                                 <f:selectItem itemLabel="Pendiente" itemValue="Pendiente" />
                                             </p:selectOneMenu>
                                         </f:facet>
-                                        <div class="apilarelementos"> 
+                                        <div class="apilarelementos">
                                             <h:outputText value="#{item.realizado eq 'Si' ? 'Realizado' : (item.realizado eq 'Pendiente' ? 'Pendiente' : 'Por Atender')}" styleClass="estadofinalizado#{item.realizado}" />
 
                                             <h:outputText  value="#{item.horaYDia}" styleClass="fechacolumna" >
                                                 <f:convertDateTime pattern="dd/MM/yyyy HH:mm" />
                                             </h:outputText>
-                                        </div> 
+                                        </div>
                                     </p:column>
                                     <p:column filterBy="#{item.responsable}" headerText="Responsable"  filterMatchMode="contains" style="width:10%" class="iconoturnorespondable" >
 
                                         <div style="display:flex;justify-content: center">
-                                            <h:outputText id="responsableicon"  
+                                            <h:outputText id="responsableicon"
                                                           value="#{expedienteController.getIniciales(item.responsable)}"
                                                           style="color:white; border-radius:50%; width:28px; height:28px;
                                                           display:flex; align-items:center; justify-content:center;
@@ -1081,7 +1094,7 @@
                         </div>
 
 
-                    </p:tab> 
+                    </p:tab>
 
                 </p:tabView>
 


### PR DESCRIPTION
### Motivation
- Implementar la misma lógica dinámica de visualización que existe para DDHH cuando el `JP Tipo` sea `LABORAL` y que los campos laborales estén disponibles en las etapas administrativo y judicial. 
- Asegurar persistencia de los datos laborales en la entidad `Expediente` y que la transformación administrativo→judicial conserve dichos datos.

### Description
- Se añadieron campos persistentes laborales a `Expediente` (`laboralTipoReclamo`, `laboralDetalleReclamo`, `laboralEmpleador`, `laboralCuit`, `laboralTrabajoRegistrado`, `laboralArt`, `laboralFechaIngreso`, `laboralFechaEgreso`, `laboralDescripcionPuesto`, `laboralJornada`, `laboralSalario`, `laboralCct`, `laboralObservaciones`, `laboralSrtTipoTramite`, `laboralSrtExpediente`, `laboralCategoriaJuicio`) y sus getters/setters. (F: `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java`)
- Se agregaron constantes y helpers en el controller para detectar `JP Tipo = LABORAL` y distinguir administrativo/judicial en Justicia Provincial, siguiendo el patrón usado para DDHH; además se reutiliza la lógica existente de `usuarioSac`. (F: `src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java`)
- Se creó un fragmento reutilizable de edición (`web/expediente/fragments/laboralEdit.xhtml`) que implementa las columnas/bloques 1 y 2 (campos administrativos) y otro fragmento de visualización (`web/expediente/fragments/laboralView.xhtml`) para mostrar los datos laborales en vistas de solo lectura.
- Se integró el panel laboral en las vistas de creación/edición/visualización y en las vistas desde agenda, con actualización AJAX al cambiar `JP Tipo` y con la columna judicial adicional (`laboralCategoriaJuicio`) solo visible en etapa judicial; se reutiliza `empleadoController.items` para el selector `Usuario SAC`. (F: múltiples XHTML en `web/expediente/*`, `web/agenda/*`, `web/expediente/viewEnAgenda/*`)
- Se agregó un script SQL de migración para crear las columnas nuevas en la tabla `Expediente`. (F: `ALTER_TABLE_EXPEDIENTE_ADD_LABORAL.sql`)

### Testing
- Se validó sintácticamente la estructura de los XHTML nuevos y modificados con `python3`/`xml.etree.ElementTree.parse`, todos los archivos parsearon correctamente. (éxito)
- Se ejecutó `git diff --check` y se corrigieron espacios finales y formato básico; no se detectaron errores críticos en diffs comprobados. (éxito)
- Intento de compilación con `ant -q compile` no se pudo ejecutar en el entorno porque `ant` no está instalado aquí, por lo que no se dispone de confirmación de compilación completa en este entorno. (no ejecutado)
- Se incluyó el SQL de migración para aplicar a la base de datos y se verificó que los fragmentos y las inclusiones están bien referenciadas; se recomienda ejecutar una compilación y pruebas en un entorno local con `ant`/Maven y aplicar la migración en staging antes del despliegue en producción.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56dec65d888327bf600aa6ff7e019c)