### PR TITLE
Restaurar botón Imprimir Carátula

### DIFF
--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -596,6 +596,30 @@
                                 <p:outputLabel value="Observaciones:" for="observaciones" />
                                 <p:inputTextarea rows="19" cols="25" autoResize="false"  id="observaciones"
                                                  value="#{expedienteController.selected.observaciones}" title="observaciones"/>
+
+                                <div>
+                                    <h:commandButton onclick="form.target = '_blank';" value="Imprimir Carátula" styleClass="boton-imprimir" actionListener="#{downloadBean.crearPdfDeCaratula(expedienteController.selected.nombre, expedienteController.selected.apellido, expedienteController.selected.dni, expedienteController.selected.direccion,
+                                                                                                                                                               expedienteController.selected.nroDeAltura, expedienteController.selected.barrio,
+                                                                                                                                                               expedienteController.selected.apoderado,
+                                                                                                                                                               expedienteController.selected.fechaDeAtencion,
+                                                                                                                                                               expedienteController.selected.sexo,
+                                                                                                                                                               expedienteController.selected.telefono,
+                                                                                                                                                               expedienteController.selected.cuit,
+                                                                                                                                                               expedienteController.selected.fechaDeNacimiento,
+                                                                                                                                                               expedienteController.selected.edad,
+                                                                                                                                                               expedienteController.selected.cobraBeneficio,
+                                                                                                                                                               expedienteController.selected.tipoDeBeneficio,
+                                                                                                                                                               expedienteController.selected.aportes,
+                                                                                                                                                               expedienteController.selected.trabajando,
+                                                                                                                                                               expedienteController.selected.inscripcionAut,
+                                                                                                                                                               expedienteController.selected.estadoCivil,
+                                                                                                                                                               expedienteController.selected.cantidadDeHijos,
+                                                                                                                                                               expedienteController.selected.obraSocial,
+                                                                                                                                                               expedienteController.selected.claveCidi,
+                                                                                                                                                               expedienteController.selected.claveFiscal,
+                                                                                                                                                               expedienteController.selected.claveSeguridadSocial
+                                                                                                                                                               )}" />
+                                </div>
                             </div>
                         </div>
 


### PR DESCRIPTION
### Motivation
- Recuperar la funcionalidad de impresión de la carátula que había sido eliminada de la vista de edición de expedientes judiciales para permitir generar el PDF desde la misma pantalla.

### Description
- Se añadió un `h:commandButton` en `web/expediente/EditExpJudicial.xhtml` que abre el PDF en una nueva pestaña y llama a `downloadBean.crearPdfDeCaratula(...)` pasando los datos del expediente seleccionado.
- La inserción es un bloque pequeño dentro de la columna de "Observaciones" para que el botón quede junto a los demás controles de la ficha de expediente.
- No se tocaron las implementaciones existentes de `DownloadBean` ni la lógica de generación de PDF, solo se reexpone la acción desde la vista.

### Testing
- Se ejecutó `git diff --check` para detectar problemas de formato en el diff y no se reportaron errores (exitoso).
- Se parseó `web/expediente/EditExpJudicial.xhtml` con `xml.etree.ElementTree` en Python para validar que el archivo es XML bien formado (éxito).
- Se comprobó que la nueva línea con `value="Imprimir Carátula"` aparece en `web/expediente/EditExpJudicial.xhtml` y que la vista contiene la invocación a `downloadBean.crearPdfDeCaratula(...)` (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f6209c78883279a645543c68c0c38)