### PR TITLE
Ocultar Tipo en expedientes judiciales Laborales

### DIFF
--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -82,8 +82,8 @@
                     <p:tab title="Datos Expediente">
                         <div style="float: left; width: 50%">
                             <h:panelGrid columns="2" cellspacing="5">
-                                <p:outputLabel value="Tipo:" for="tipo" style="font-weight: bold" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}"/>
-                                <p:selectOneMenu id="tipo" style="margin-left: 3%" value="#{expedienteController.selected.tipo}" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}" >
+                                <p:outputLabel value="Tipo:" for="tipo" style="font-weight: bold" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}"/>
+                                <p:selectOneMenu id="tipo" style="margin-left: 3%" value="#{expedienteController.selected.tipo}" rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" >
                                         <f:selectItem itemLabel="Reajustes" itemValue="Reajuste" />
                                         <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
                                         <f:selectItem itemLabel="Amparos" itemValue="Amparos" />

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -347,11 +347,11 @@
 
                                 <p:outputLabel value="Tipo:"
                                                for="tipo"
-                                               rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}" />
+                                               rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" />
                                 <p:selectOneMenu editable="true"
                                                  id="tipo"
                                                  value="#{expedienteController.selected.tipo}"
-                                                 rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial}" >
+                                                 rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" >
                                     <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
                                     <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
                                     <f:selectItem itemLabel="Amparos" itemValue="Amparos" />

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -338,8 +338,8 @@
                         <div class="datosexpediente">
                             <div class="columna">
 
-                                <p:outputLabel value="Tipo:" for="tipo" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial}" />
-                                <p:selectOneMenu   editable="true" id="tipo"  value="#{expedienteController.selectedParaVerExp.tipo}" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial}" >
+                                <p:outputLabel value="Tipo:" for="tipo" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}" />
+                                <p:selectOneMenu   editable="true" id="tipo"  value="#{expedienteController.selectedParaVerExp.tipo}" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}" >
                                     <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
                                     <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
                                     <f:selectItem itemLabel="Amparos" itemValue="Amparos" />


### PR DESCRIPTION
### Motivation
- Ajustar la presentación para que, en la pestaña `Laboral` de Justicia Provincial, el campo visual “Tipo” no se muestre, replicando exactamente el comportamiento ya existente para `DDHH` y sin tocar la persistencia ni la entidad.
- Reusar la lógica y predicados existentes del controlador (`ExpedienteController`) para DDHH/Laboral y aplicar la misma condición de renderizado en las vistas correspondientes.

### Description
- Se modificaron solo las vistas JSF para ocultar `Tipo` cuando el expediente es judicial y `jpTipo = LABORAL`, añadiendo la condición `and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial` (o su variante `ParaVer`) a los `rendered` del `p:outputLabel` y `p:selectOneMenu` de `id="tipo"` en los tres archivos: `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/EditExpJudicial.xhtml` y `web/expediente/viewEnAgenda/EditExpJudicial.xhtml`.
- No se tocaron entidades, controladores Java ni la base de datos; las propiedades relevantes siguen siendo `Expediente.tipo` (campo visual “Tipo”), `Expediente.jpTipo` (campo visual “JP Tipo”) y `Expediente.equipo` (Equipo), y la implementación reutiliza los predicados existentes como `isExpedienteJudicialDdhhJusticiaProvincial` y `isExpedienteLaboralJusticiaProvincial` expuestos por `ExpedienteController`.

### Testing
- Verifiqué que los tres archivos XHTML modificados sean XML bien formados usando Python `xml.etree.ElementTree.parse(...)`, y la verificación devolvió `OK` para cada archivo.
- Ejecuté `git diff --check` y `git diff` para confirmar que el diff es limpio y commité los cambios con el mensaje `Ocultar tipo para expedientes laborales` (commit `07cb870`).
- Intenté ejecutar el build con `ant clean dist` pero no fue posible porque `ant` no está instalado en el entorno (`ant: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6151d872248327936d71321c1b583d)