### PR TITLE
Add workplace claim type options

### DIFF
--- a/web/expediente/fragments/laboralEdit.xhtml
+++ b/web/expediente/fragments/laboralEdit.xhtml
@@ -11,6 +11,9 @@
             <f:selectItem itemLabel="Ordinario - Despido" itemValue="Ordinario - Despido" />
             <f:selectItem itemLabel="Ordinario - Otros" itemValue="Ordinario - Otros" />
             <f:selectItem itemLabel="PDA" itemValue="PDA" />
+            <f:selectItem itemLabel="Accidente laboral" itemValue="Accidente laboral" />
+            <f:selectItem itemLabel="Accidente in itinere" itemValue="Accidente in itinere" />
+            <f:selectItem itemLabel="Enfermedad Profesional" itemValue="Enfermedad Profesional" />
             <f:selectItem itemLabel="Otro" itemValue="Otro" />
         </p:selectOneMenu>
         <p:outputLabel value="Detalle de siniestro/reclamo:" for="laboralDetalleReclamo" />


### PR DESCRIPTION
### Motivation
- Add specific workplace-related claim types to the labor claim selector so users can record workplace accidents and occupational diseases.

### Description
- Inserted three new `<f:selectItem>` options (`Accidente laboral`, `Accidente in itinere`, `Enfermedad Profesional`) into `web/expediente/fragments/laboralEdit.xhtml` in the "Tipo de reclamo laboral" selector.

### Testing
- Ran `git diff --check` (no issues), verified the three new selector options are present in `web/expediente/fragments/laboralEdit.xhtml` via search, and attempted `ant -p` but Apache Ant is not installed in the environment so build could not be exercised.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6159cf44c883279ef4bdd9d0f81b82)