### PR TITLE
Eliminar tipo 'LABORAL-LEY DE RIESGO'

### DIFF
--- a/web/agenda/ViewExp_DesdeEditAgenda.xhtml
+++ b/web/agenda/ViewExp_DesdeEditAgenda.xhtml
@@ -147,7 +147,6 @@
                                             <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                             <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                             <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                            <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                             <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                             <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                         </p:selectOneMenu>

--- a/web/consulta/Create.xhtml
+++ b/web/consulta/Create.xhtml
@@ -199,7 +199,6 @@
                                             <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                             <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                             <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                            <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                             <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                             <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                         </p:selectOneMenu>

--- a/web/consulta/Edit.xhtml
+++ b/web/consulta/Edit.xhtml
@@ -60,7 +60,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                         </p:selectOneMenu>

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -137,7 +137,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="@form" />

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -96,7 +96,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="@form" />

--- a/web/expediente/CreateExpSinCarpeta.xhtml
+++ b/web/expediente/CreateExpSinCarpeta.xhtml
@@ -127,7 +127,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     </p:selectOneMenu>

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -377,7 +377,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="@form" />

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -373,7 +373,6 @@
                                 <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                 <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                 <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                 <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                 <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                 <p:ajax update="@form" />

--- a/web/expediente/EditExpSinCarpeta.xhtml
+++ b/web/expediente/EditExpSinCarpeta.xhtml
@@ -60,7 +60,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     </p:selectOneMenu>

--- a/web/expediente/viewEnAgenda/Edit.xhtml
+++ b/web/expediente/viewEnAgenda/Edit.xhtml
@@ -335,7 +335,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="@form" />

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -354,7 +354,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     <p:ajax update="@form" />

--- a/web/expediente/viewEnAgenda/EditExpSinCarpeta.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpSinCarpeta.xhtml
@@ -58,7 +58,6 @@
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
                                     <f:selectItem itemLabel="DDHH" itemValue="DDHH" />
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
-                                    <f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
                                     </p:selectOneMenu>


### PR DESCRIPTION
### Motivation

- Estandarizar la clasificación laboral dejando únicamente `LABORAL` y eliminar la opción obsoleta o no deseada `LABORAL-LEY DE RIESGO` en los formularios de expediente, consulta y agenda.

### Description

- Se eliminó la línea `<f:selectItem itemLabel="LABORAL-LEY DE RIESGO" itemValue="LABORAL-LEY DE RIESGO" />` de 12 vistas XHTML relacionadas con expedientes, consulta y agenda. 
- Las vistas modificadas incluyen `web/expediente/Create.xhtml`, `web/expediente/Edit.xhtml`, `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/EditExpJudicial.xhtml`, `web/expediente/CreateExpSinCarpeta.xhtml`, `web/expediente/EditExpSinCarpeta.xhtml`, `web/expediente/viewEnAgenda/*`, `web/consulta/*` y `web/agenda/ViewExp_DesdeEditAgenda.xhtml`.
- Se mantuvo la opción `LABORAL` y las demás entradas del `p:selectOneMenu` sin cambios funcionales adicionales. 
- Cambios registrados en un commit con mensaje `Eliminar tipo laboral de ley de riesgo`.

### Testing

- Se validó que las 12 vistas modificadas sean XML válido ejecutando `ET.parse(path)` sobre cada archivo y la validación pasó sin excepciones. 
- Se ejecutaron aserciones que verifican que cada vista contiene exactamente una opción `itemValue="LABORAL"` y que no contiene la cadena `LEY DE RIESGO`, y las aserciones pasaron. 
- Se ejecutó `git diff --check` sin reportar errores. 
- Intento de ejecutar `ant -p` falló porque `ant` no está instalado en el entorno, esto no afecta la corrección del selector pero impidió una verificación de build completa en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6159fafef88327bce6f1c4e5aa51b1)