### PR TITLE
Evitar el cambio de pestaña al seleccionar JP Tipo

### DIFF
--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -379,7 +379,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="@form" />
+                                    <p:ajax process="@this" update="ddhhPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                     <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoDdhhJusticiaProvincial}">


### PR DESCRIPTION
### Motivation
- Corregir un comportamiento donde al elegir un valor en “JP Tipo” la vista volvía automáticamente a la pestaña “Datos personales” porque la actualización AJAX re-renderizaba todo el formulario.

### Description
- En `web/expediente/Edit.xhtml` se reemplazó la línea `<p:ajax update="@form" />` por `<p:ajax process="@this" update="ddhhPanel" />` para procesar sólo el selector que originó el cambio y actualizar únicamente el panel condicional `ddhhPanel`.

### Testing
- Se validó que `web/expediente/Edit.xhtml` sigue siendo XML válido mediante `ET.parse` en Python.
- Se comprobó estáticamente que el `p:selectOneMenu` de `jpTipo` contiene `<p:ajax process="@this" update="ddhhPanel" />` y que `update="@form"` ya no está presente.
- Se ejecutó `git diff --check` para detectar problemas de formato y no se reportaron errores de espacio en blanco.
- Intento de ejecutar `ant` falló porque el binario `ant` no está instalado en el entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6576deb5e083279668c6ffef17ad50)