### PR TITLE
Implementar Jurisdicción Voluntaria en Justicia Provincial

### DIFF
--- a/ALTER_TABLE_EXPEDIENTE_ADD_JURISDICCION_VOLUNTARIA.sql
+++ b/ALTER_TABLE_EXPEDIENTE_ADD_JURISDICCION_VOLUNTARIA.sql
@@ -1,0 +1,6 @@
+ALTER TABLE Expediente
+    ADD COLUMN jurisdiccionVoluntariaSumariaInformacion TINYINT(1) NULL,
+    ADD COLUMN jurisdiccionVoluntariaLimitacionCapacidad TINYINT(1) NULL,
+    ADD COLUMN jurisdiccionVoluntariaOtro TINYINT(1) NULL,
+    ADD COLUMN jurisdiccionVoluntariaOtroDetalle VARCHAR(255) NULL,
+    ADD COLUMN jurisdiccionVoluntariaObservaciones TEXT NULL;

--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -396,6 +396,21 @@ public class Expediente implements Serializable {
     @Column(name = "laboralCategoriaJuicio")
     private String laboralCategoriaJuicio;
 
+    @Column(name = "jurisdiccionVoluntariaSumariaInformacion")
+    private Boolean jurisdiccionVoluntariaSumariaInformacion;
+
+    @Column(name = "jurisdiccionVoluntariaLimitacionCapacidad")
+    private Boolean jurisdiccionVoluntariaLimitacionCapacidad;
+
+    @Column(name = "jurisdiccionVoluntariaOtro")
+    private Boolean jurisdiccionVoluntariaOtro;
+
+    @Column(name = "jurisdiccionVoluntariaOtroDetalle")
+    private String jurisdiccionVoluntariaOtroDetalle;
+
+    @Column(name = "jurisdiccionVoluntariaObservaciones")
+    private String jurisdiccionVoluntariaObservaciones;
+
 
     public Expediente() {
     }
@@ -1225,6 +1240,17 @@ public class Expediente implements Serializable {
     public void setLaboralSrtExpediente(String laboralSrtExpediente) { this.laboralSrtExpediente = laboralSrtExpediente; }
     public String getLaboralCategoriaJuicio() { return laboralCategoriaJuicio; }
     public void setLaboralCategoriaJuicio(String laboralCategoriaJuicio) { this.laboralCategoriaJuicio = laboralCategoriaJuicio; }
+
+    public Boolean getJurisdiccionVoluntariaSumariaInformacion() { return jurisdiccionVoluntariaSumariaInformacion; }
+    public void setJurisdiccionVoluntariaSumariaInformacion(Boolean value) { this.jurisdiccionVoluntariaSumariaInformacion = value; }
+    public Boolean getJurisdiccionVoluntariaLimitacionCapacidad() { return jurisdiccionVoluntariaLimitacionCapacidad; }
+    public void setJurisdiccionVoluntariaLimitacionCapacidad(Boolean value) { this.jurisdiccionVoluntariaLimitacionCapacidad = value; }
+    public Boolean getJurisdiccionVoluntariaOtro() { return jurisdiccionVoluntariaOtro; }
+    public void setJurisdiccionVoluntariaOtro(Boolean value) { this.jurisdiccionVoluntariaOtro = value; }
+    public String getJurisdiccionVoluntariaOtroDetalle() { return jurisdiccionVoluntariaOtroDetalle; }
+    public void setJurisdiccionVoluntariaOtroDetalle(String value) { this.jurisdiccionVoluntariaOtroDetalle = value; }
+    public String getJurisdiccionVoluntariaObservaciones() { return jurisdiccionVoluntariaObservaciones; }
+    public void setJurisdiccionVoluntariaObservaciones(String value) { this.jurisdiccionVoluntariaObservaciones = value; }
 
 
     public boolean equals(Object object) {

--- a/src/java/com/estudioAlvarezVersion2/jsf/EmpleadoController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/EmpleadoController.java
@@ -330,6 +330,18 @@ public class EmpleadoController implements Serializable {
         return items;
     }
 
+    /** Empleados cuyo cargo está identificado como abogado/a. */
+    public List<Empleado> getAbogados() {
+        List<Empleado> abogados = new ArrayList<>();
+        for (Empleado empleado : getItems()) {
+            if (empleado.getCargo() != null
+                    && empleado.getCargo().trim().toUpperCase().contains("ABOGAD")) {
+                abogados.add(empleado);
+            }
+        }
+        return abogados;
+    }
+
     private void persist(PersistAction persistAction, String successMessage) {
         if (selected != null) {
             setEmbeddableKeys();

--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -102,6 +102,7 @@ public class ExpedienteController implements Serializable {
     private static final String SIN_CARPETA = "sin carpeta";
     private static final String DDHH = "DDHH";
     private static final String LABORAL = "LABORAL";
+    private static final String JURISDICCION_VOLUNTARIA = "JURISDICCIÓN VOLUNTARIA";
     private static final String JUSTICIA_PROVINCIAL = "JUSTICIA PROVINCIAL";
 
 
@@ -316,6 +317,20 @@ public class ExpedienteController implements Serializable {
         return isExpedienteJudicialLaboralJusticiaProvincial(selected);
     }
 
+    public boolean isExpedienteSeleccionadoJurisdiccionVoluntaria() {
+        return isExpedienteJurisdiccionVoluntaria(selected);
+    }
+
+    public boolean isExpedienteParaVerSeleccionadoJurisdiccionVoluntaria() {
+        return isExpedienteJurisdiccionVoluntaria(selectedParaVerExp);
+    }
+
+    private boolean isExpedienteJurisdiccionVoluntaria(Expediente expediente) {
+        return expediente != null
+                && equalsIgnoreCaseTrim(expediente.getEquipo(), JUSTICIA_PROVINCIAL)
+                && equalsIgnoreCaseTrim(expediente.getJpTipo(), JURISDICCION_VOLUNTARIA);
+    }
+
     public boolean isExpedienteParaVerSeleccionadoLaboralJusticiaProvincial() {
         return isExpedienteLaboralJusticiaProvincial(selectedParaVerExp);
     }
@@ -366,6 +381,12 @@ public class ExpedienteController implements Serializable {
     private void limpiarUsuarioSacSiNoCorresponde() {
         if (selected != null && !isExpedienteJudicialJusticiaProvincial(selected)) {
             selected.setUsuarioSac(null);
+        }
+    }
+
+    private void normalizarJurisdiccionVoluntaria() {
+        if (selected != null && Boolean.FALSE.equals(selected.getJurisdiccionVoluntariaOtro())) {
+            selected.setJurisdiccionVoluntariaOtroDetalle(null);
         }
     }
 
@@ -541,6 +562,7 @@ public class ExpedienteController implements Serializable {
     public void create() {
 
         limpiarUsuarioSacSiNoCorresponde();
+        normalizarJurisdiccionVoluntaria();
         ingresarEdad();
 
         ingresarDni();
@@ -642,6 +664,7 @@ public class ExpedienteController implements Serializable {
         selected.setDni(extractDniFromCuit(selected.getCuit()));
 
         limpiarUsuarioSacSiNoCorresponde();
+        normalizarJurisdiccionVoluntaria();
 
         String successMessage = "Expediente actualizado exitosamente";
 

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -226,12 +226,21 @@
                                         </h:panelGroup>
                                     </h:panelGroup>
 
+                                    <h:panelGroup id="jurisdiccionVoluntariaPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}">
+                                            <ui:include src="/expediente/fragments/jurisdiccionVoluntariaEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
 <p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
 
                                         <p:selectOneMenu style="margin-left: 1%; margin-right: 1%" id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                             <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                             <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
-                                        </p:selectOneMenu>
+                                            <p:ajax process="@this" update="@form" />
+</p:selectOneMenu>
 
                                     </div>
 
@@ -273,7 +282,8 @@
                                     <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
                                     <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                         <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
-                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                        <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
                                     </p:selectOneMenu>
 
                                     <p:outputLabel value="Expediente físico:" for="fisico" style="font-weight: bold" />

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -98,7 +98,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="tipoDeExpedientePanel laboralPanel" />
+                                    <p:ajax update="tipoDeExpedientePanel laboralPanel jurisdiccionVoluntariaPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">
@@ -183,6 +183,14 @@
                                         </h:panelGroup>
                                     </h:panelGroup>
 
+                                    <h:panelGroup id="jurisdiccionVoluntariaPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}">
+                                            <ui:include src="/expediente/fragments/jurisdiccionVoluntariaEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
 <p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
 
                                          <p:selectOneMenu style="margin-left: 1%; margin-right: 1%" id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
@@ -252,7 +260,8 @@
                                         <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
                                         <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                             <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
-                                            <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                            <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
                                         </p:selectOneMenu>
                                     </h:panelGroup>
                             <br></br><br></br>

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -467,11 +467,20 @@
                                         </h:panelGroup>
                                     </h:panelGroup>
 
+                                    <h:panelGroup id="jurisdiccionVoluntariaPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}">
+                                            <ui:include src="/expediente/fragments/jurisdiccionVoluntariaEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
 <p:outputLabel value="Equipo:" for="equipo"  />
                                     <p:selectOneMenu id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
                                         <f:selectItem itemLabel=" -- Elige un equipo --"  noSelectionOption="true"  />
                                         <f:selectItems value="#{equipoController.items}" var="equipo" itemLabel="#{equipo.nombre}" itemValue="#{equipo.nombre}" />
-                                    </p:selectOneMenu>
+                                        <p:ajax process="@this" update="@form" />
+</p:selectOneMenu>
 
                                 </div>
                                 <div class="columna">
@@ -505,7 +514,8 @@
                                     <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
                                     <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                         <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
-                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                        <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
                                     </p:selectOneMenu>
                                 </div>
                                 <div class="columna">

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -455,6 +455,14 @@
                                     </h:panelGroup>
                                 </h:panelGroup>
 
+                                <h:panelGroup id="jurisdiccionVoluntariaPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                    <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}">
+                                        <ui:include src="/expediente/fragments/jurisdiccionVoluntariaEdit.xhtml">
+                                            <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                        </ui:include>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
 <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
                                     <p:commandButton value="Si" type="button" styleClass="ui-confirmdialog-no" icon="pi pi-times" update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm" />
                                 </p:confirmDialog>
@@ -586,8 +594,12 @@
                                 <p:selectOneMenu rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"
                                                  id="usuarioSac" value="#{expedienteController.selected.usuarioSac}">
                                     <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
+                                    <f:selectItems value="#{empleadoController.abogados}" var="empleado"
+                                                   itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"
+                                                   rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
                                     <f:selectItems value="#{empleadoController.items}" var="empleado"
-                                                   itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" />
+                                                   itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"
+                                                   rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
                                 </p:selectOneMenu>
 
                             </div>

--- a/web/expediente/fragments/jurisdiccionVoluntariaEdit.xhtml
+++ b/web/expediente/fragments/jurisdiccionVoluntariaEdit.xhtml
@@ -1,0 +1,25 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui">
+    <div class="columna">
+        <p:outputLabel value="Tipo de trámite" style="font-weight: bold" />
+        <p:selectBooleanCheckbox id="jvSumaria" value="#{expediente.jurisdiccionVoluntariaSumariaInformacion}" itemLabel="Sumaria información" />
+        <p:selectBooleanCheckbox id="jvLimitacion" value="#{expediente.jurisdiccionVoluntariaLimitacionCapacidad}" itemLabel="Limitación a la capacidad" />
+        <p:selectBooleanCheckbox id="jvOtro" value="#{expediente.jurisdiccionVoluntariaOtro}" itemLabel="Otro">
+            <p:ajax process="@this" update="jvOtroDetallePanel" />
+        </p:selectBooleanCheckbox>
+        <h:panelGroup id="jvOtroDetallePanel" layout="block">
+            <p:outputLabel value="Detalle de Otro:" for="jvOtroDetalle" rendered="#{expediente.jurisdiccionVoluntariaOtro}" />
+            <p:inputText id="jvOtroDetalle" value="#{expediente.jurisdiccionVoluntariaOtroDetalle}"
+                         required="#{expediente.jurisdiccionVoluntariaOtro}"
+                         requiredMessage="Debe completar el detalle de Otro."
+                         rendered="#{expediente.jurisdiccionVoluntariaOtro}" />
+        </h:panelGroup>
+    </div>
+    <div class="columna">
+        <p:outputLabel value="Observaciones" for="jvObservaciones" style="font-weight: bold" />
+        <p:inputTextarea id="jvObservaciones" value="#{expediente.jurisdiccionVoluntariaObservaciones}"
+                         rows="10" cols="30" autoResize="false" />
+    </div>
+</ui:composition>


### PR DESCRIPTION
### Motivation
- Agregar el tipo provincial “JURISDICCIÓN VOLUNTARIA” reutilizando la misma lógica, estructura y flujo administrativo→judicial ya implementado para `LABORAL` sin refactorizaciones globales. 

### Description
- Persistencia: añadí campos nullable en la entidad `Expediente` para los datos administrativos de Jurisdicción Voluntaria: `jurisdiccionVoluntariaSumariaInformacion`, `jurisdiccionVoluntariaLimitacionCapacidad`, `jurisdiccionVoluntariaOtro`, `jurisdiccionVoluntariaOtroDetalle` y `jurisdiccionVoluntariaObservaciones`, con sus getters/setters y la sentencia SQL en `ALTER_TABLE_EXPEDIENTE_ADD_JURISDICCION_VOLUNTARIA.sql`.
- Vistas y fragmento: creé el fragmento reutilizable `web/expediente/fragments/jurisdiccionVoluntariaEdit.xhtml` que muestra las tres casillas (Sumaria información, Limitación a la capacidad, Otro + detalle condicional) y el `textarea` Observaciones, y lo incluí en las pantallas de `Create.xhtml`, `Edit.xhtml`, `CreateExpJudicial.xhtml` y `EditExpJudicial.xhtml` mediante `ui:include` y paneles condicionados.
- Lógica de control: en `ExpedienteController` añadí la constante `JURISDICCION_VOLUNTARIA`, funciones de renderizado `isExpedienteSeleccionadoJurisdiccionVoluntaria()` y la validación/normalización que limpia `OtroDetalle` cuando `Otro` está desmarcado; usé el mismo criterio ya existente para distinguir administrativo → judicial (`tipoDeExpediente == "judicial"` para el estado judicial) y `jpTipo` + `equipo == "JUSTICIA PROVINCIAL"` para activar el bloque.
- Usuario SAC: reutilicé el campo `usuarioSac` existente y cambié el `selectOneMenu` para que, únicamente cuando el expediente sea Jurisdicción Voluntaria, muestre la lista filtrada de abogados obtenida desde `EmpleadoController.getAbogados()` (filtro por `empleado.getCargo()` que contiene `ABOGAD`) sin hardcodear nombres ni duplicar entidades.
- Integración AJAX y compatibilidad: añadí `p:ajax` para actualizar los paneles relevantes al cambiar `jpTipo`, `equipo` o el checkbox `Otro`, manteniendo el mismo `<h:form>` y evitando formularios anidados; no se tocaron los fragmentos/condiciones de `LABORAL` ni de otros tipos.

### Testing
- Parseo XML de vistas: parseé programáticamente los XHTML modificados y el nuevo fragmento (`xml.etree.ElementTree.parse`) y todos resultaron bien formados (OK).
- Revisión estática: ejecuté `git diff --check` y búsquedas (`rg`) para confirmar que las inclusiones, el selector `jpTipo` y el nuevo `jurisdiccionVoluntariaPanel` están presentes en `Create.xhtml`, `Edit.xhtml`, `CreateExpJudicial.xhtml` y `EditExpJudicial.xhtml` (OK).
- Validaciones de UI-data binding: verifiqué que los nuevos campos en `Expediente` son `Boolean`/`String` (nullable) para mantener compatibilidad con expedientes históricos y que el detalle de `Otro` se limpia en `create()`/`update()` cuando corresponde (OK).
- Compilación del proyecto: intenté `ant -q clean jar` pero no fue posible confirmar la compilación en este entorno porque Apache Ant no está instalado (`ant: command not found`) (no ejecutado aquí).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ca17119a48327ab12d7fc12562368)