### PR TITLE
Fix JP Tipo AJAX refresh and remove obsolete Provincia subcategories

### DIFF
--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -139,7 +139,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="@form" />
+                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -98,7 +98,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="tipoDeExpedientePanel laboralPanel jurisdiccionVoluntariaPanel" />
+                                    <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -379,7 +379,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax process="@this" update="ddhhPanel" />
+                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                     <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoDdhhJusticiaProvincial}">

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -375,7 +375,7 @@
                                 <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                 <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                 <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                <p:ajax update="@form" />
+                                <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
                                 </p:selectOneMenu>
 
                                 <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
@@ -511,15 +511,6 @@
                                         <f:selectItem itemValue="Imp. Ganancias" itemLabel="Imp. Ganancias" />
                                         <f:selectItem itemValue="Apelación dictamen CMC" itemLabel="Apelación dictamen CMC" />
                                         <f:selectItem itemValue="Laboral" itemLabel="Laboral" />
-                                    </p:selectManyCheckbox>
-
-                                    <p:selectManyCheckbox
-                                        layout="pageDirection" value="#{expedienteController.selected.subCategoriasDeTipo}"
-                                        rendered="#{expedienteController.selected.tipo eq 'Provincia'}">
-                                        <f:selectItem itemValue="DD.HH" itemLabel="DD.HH" />
-                                        <f:selectItem itemValue="A.R.T" itemLabel="A.R.T" />
-                                        <f:selectItem itemValue="Despido" itemLabel="Despido" />
-                                        <f:selectItem itemValue="Otros" itemLabel="otros" />
                                     </p:selectManyCheckbox>
 
                                 </div>

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -345,22 +345,24 @@
                                 </p:selectOneMenu>
 
 
-                                <p:outputLabel value="Tipo:"
-                                               for="tipo"
-                                               rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" />
-                                <p:selectOneMenu editable="true"
-                                                 id="tipo"
-                                                 value="#{expedienteController.selected.tipo}"
-                                                 rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" >
-                                    <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
-                                    <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
-                                    <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
-                                    <f:selectItem itemLabel="Otros" itemValue="Otros" />
-                                    <f:selectItem itemLabel="Provincia" itemValue="Provincia" />
-                                    <f:selectItem itemLabel="Impuesto a las Ganancias" itemValue="Impuesto a las Ganancias" />
+                                <h:panelGroup id="tipoDeExpedientePanel" layout="block">
+                                    <p:outputLabel value="Tipo:"
+                                                   for="tipo"
+                                                   rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" />
+                                    <p:selectOneMenu editable="true"
+                                                     id="tipo"
+                                                     value="#{expedienteController.selected.tipo}"
+                                                     rendered="#{not expedienteController.expedienteSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteSeleccionadoJudicialLaboralJusticiaProvincial}" >
+                                        <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
+                                        <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
+                                        <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
+                                        <f:selectItem itemLabel="Otros" itemValue="Otros" />
+                                        <f:selectItem itemLabel="Provincia" itemValue="Provincia" />
+                                        <f:selectItem itemLabel="Impuesto a las Ganancias" itemValue="Impuesto a las Ganancias" />
 
-                                    <p:ajax event="change" update="confirmdialog" oncomplete="PF('confirm').show()" />
-                                </p:selectOneMenu>
+                                        <p:ajax event="change" update="confirmdialog" oncomplete="PF('confirm').show()" />
+                                    </p:selectOneMenu>
+                                </h:panelGroup>
 
                                 <p:outputLabel rendered="#{expedienteController.expedienteSeleccionadoJusticiaProvincial}"
                                                value="JP Tipo:"

--- a/web/expediente/viewEnAgenda/Edit.xhtml
+++ b/web/expediente/viewEnAgenda/Edit.xhtml
@@ -337,7 +337,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="@form" />
+                                    <p:ajax process="@this" update="laboralPanel" />
                                     </p:selectOneMenu>
 
 

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -338,17 +338,19 @@
                         <div class="datosexpediente">
                             <div class="columna">
 
-                                <p:outputLabel value="Tipo:" for="tipo" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}" />
-                                <p:selectOneMenu   editable="true" id="tipo"  value="#{expedienteController.selectedParaVerExp.tipo}" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}" >
-                                    <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
-                                    <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
-                                    <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
-                                    <f:selectItem itemLabel="Otros" itemValue="Otros" />
-                                    <f:selectItem itemLabel="Provincia" itemValue="Provincia" />
-                                    <f:selectItem itemLabel="Impuesto a las Ganancias" itemValue="Impuesto a las Ganancias" />
+                                <h:panelGroup id="tipoPanel" layout="block">
+                                    <p:outputLabel value="Tipo:" for="tipo" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}" />
+                                    <p:selectOneMenu editable="true" id="tipo" value="#{expedienteController.selectedParaVerExp.tipo}" rendered="#{not expedienteController.expedienteParaVerSeleccionadoJudicialDdhhJusticiaProvincial and not expedienteController.expedienteParaVerSeleccionadoJudicialLaboralJusticiaProvincial}">
+                                        <f:selectItem itemLabel="Reajustes" itemValue="Reajustes" />
+                                        <f:selectItem itemLabel="Pensiones" itemValue="Pensiones" />
+                                        <f:selectItem itemLabel="Amparos" itemValue="Amparos" />
+                                        <f:selectItem itemLabel="Otros" itemValue="Otros" />
+                                        <f:selectItem itemLabel="Provincia" itemValue="Provincia" />
+                                        <f:selectItem itemLabel="Impuesto a las Ganancias" itemValue="Impuesto a las Ganancias" />
 
-                                    <p:ajax event="change" update="confirmdialog" oncomplete="PF('confirm').show()" />
-                                </p:selectOneMenu>
+                                        <p:ajax event="change" update="confirmdialog" oncomplete="PF('confirm').show()" />
+                                    </p:selectOneMenu>
+                                </h:panelGroup>
                                     <p:outputLabel value="JP Tipo:" for="jpTipo" style="font-weight: bold" />
                                     <p:selectOneMenu id="jpTipo" value="#{expedienteController.selectedParaVerExp.jpTipo}" editable="true">
                                     <f:selectItem itemLabel=" -- Elige un JP Tipo --" noSelectionOption="true" />
@@ -356,7 +358,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax process="@this" update="laboralPanel" />
+                                    <p:ajax process="@this" update="tipoPanel laboralPanel" />
                                     </p:selectOneMenu>
 
 

--- a/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
+++ b/web/expediente/viewEnAgenda/EditExpJudicial.xhtml
@@ -356,7 +356,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax update="@form" />
+                                    <p:ajax process="@this" update="laboralPanel" />
                                     </p:selectOneMenu>
 
 
@@ -419,13 +419,6 @@
                                         <f:selectItem itemValue="Imp. Ganancias" itemLabel="Imp. Ganancias" />
                                         <f:selectItem itemValue="Apelación dictamen CMC" itemLabel="Apelación dictamen CMC" />
                                         <f:selectItem itemValue="Laboral" itemLabel="Laboral" />
-                                    </p:selectManyCheckbox>
-
-                                    <p:selectManyCheckbox layout="pageDirection" value="#{expedienteController.selectedParaVerExp.subCategoriasDeTipo}"  rendered="#{expedienteController.selectedParaVerExp.tipo eq 'Provincia'}">
-                                        <f:selectItem itemValue="DD.HH" itemLabel="DD.HH" />
-                                        <f:selectItem itemValue="A.R.T" itemLabel="A.R.T" />
-                                        <f:selectItem itemValue="Despido" itemLabel="Despido" />
-                                        <f:selectItem itemValue="Otros" itemLabel="otros" />
                                     </p:selectManyCheckbox>
 
                                 </div>


### PR DESCRIPTION
### Motivation
- Changing `JP Tipo` (e.g. to `LABORAL` or `JURISDICCIÓN VOLUNTARIA`) was triggering a full form/tab refresh that returned the UI to the "Datos personales" panel, so the AJAX should only process the changed field and update the related panels. 
- Some old `Provincia` subcategory options (`DD.HH`, `A.R.T`, `Despido`, `otros`) were still being rendered in judicial edit screens and needed to be removed.

### Description
- Tighten `p:ajax` on `JP Tipo` selectors to `process="@this"` and limit `update` to the specific panels (`ddhhPanel`, `laboralPanel`, `jurisdiccionVoluntariaPanel`, `tipoDeExpedientePanel`) so switching JP Tipo does not refresh the whole form. 
- Remove obsolete `Provincia` `p:selectManyCheckbox` blocks from judicial edit screens where they could appear incorrectly. 
- Changes applied to the following facelets: `web/expediente/Create.xhtml`, `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/Edit.xhtml`, `web/expediente/EditExpJudicial.xhtml`, `web/expediente/viewEnAgenda/Edit.xhtml`, and `web/expediente/viewEnAgenda/EditExpJudicial.xhtml`.

### Testing
- Ran `git diff --check` and there were no whitespace/merge issues. 
- Parsed all modified XHTML files with Python `xml.etree.ElementTree.parse` (files listed above) and each parsed successfully. 
- Attempted to run `ant clean jar` but the command failed because `ant` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73a4c478f0832780c8c6d4e57c9c3a)