### PR TITLE
Agregar JP Tipo 'OTROS' end-to-end (persistencia, vistas y lógica JSF)

### DIFF
--- a/ALTER_TABLE_EXPEDIENTE_ADD_OTROS.sql
+++ b/ALTER_TABLE_EXPEDIENTE_ADD_OTROS.sql
@@ -1,0 +1,10 @@
+ALTER TABLE Expediente
+    ADD COLUMN otrosDanosAccidente TINYINT(1) NULL,
+    ADD COLUMN otrosDanosIncumplimientoContractualLeySeguros TINYINT(1) NULL,
+    ADD COLUMN otrosDivorcio TINYINT(1) NULL,
+    ADD COLUMN otrosOtroSeleccionado TINYINT(1) NULL,
+    ADD COLUMN otrosDemandado VARCHAR(255) NULL,
+    ADD COLUMN otrosCuit VARCHAR(255) NULL,
+    ADD COLUMN otrosDomicilio VARCHAR(255) NULL,
+    ADD COLUMN otrosTerceroCitadoGarantia VARCHAR(255) NULL,
+    ADD COLUMN otrosObservaciones TEXT NULL;

--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -411,6 +411,33 @@ public class Expediente implements Serializable {
     @Column(name = "jurisdiccionVoluntariaObservaciones")
     private String jurisdiccionVoluntariaObservaciones;
 
+    @Column(name = "otrosDanosAccidente")
+    private Boolean otrosDanosAccidente;
+
+    @Column(name = "otrosDanosIncumplimientoContractualLeySeguros")
+    private Boolean otrosDanosIncumplimientoContractualLeySeguros;
+
+    @Column(name = "otrosDivorcio")
+    private Boolean otrosDivorcio;
+
+    @Column(name = "otrosOtroSeleccionado")
+    private Boolean otrosOtroSeleccionado;
+
+    @Column(name = "otrosDemandado")
+    private String otrosDemandado;
+
+    @Column(name = "otrosCuit")
+    private String otrosCuit;
+
+    @Column(name = "otrosDomicilio")
+    private String otrosDomicilio;
+
+    @Column(name = "otrosTerceroCitadoGarantia")
+    private String otrosTerceroCitadoGarantia;
+
+    @Column(name = "otrosObservaciones")
+    private String otrosObservaciones;
+
 
     public Expediente() {
     }
@@ -1251,6 +1278,25 @@ public class Expediente implements Serializable {
     public void setJurisdiccionVoluntariaOtroDetalle(String value) { this.jurisdiccionVoluntariaOtroDetalle = value; }
     public String getJurisdiccionVoluntariaObservaciones() { return jurisdiccionVoluntariaObservaciones; }
     public void setJurisdiccionVoluntariaObservaciones(String value) { this.jurisdiccionVoluntariaObservaciones = value; }
+
+    public Boolean getOtrosDanosAccidente() { return otrosDanosAccidente; }
+    public void setOtrosDanosAccidente(Boolean value) { this.otrosDanosAccidente = value; }
+    public Boolean getOtrosDanosIncumplimientoContractualLeySeguros() { return otrosDanosIncumplimientoContractualLeySeguros; }
+    public void setOtrosDanosIncumplimientoContractualLeySeguros(Boolean value) { this.otrosDanosIncumplimientoContractualLeySeguros = value; }
+    public Boolean getOtrosDivorcio() { return otrosDivorcio; }
+    public void setOtrosDivorcio(Boolean value) { this.otrosDivorcio = value; }
+    public Boolean getOtrosOtroSeleccionado() { return otrosOtroSeleccionado; }
+    public void setOtrosOtroSeleccionado(Boolean value) { this.otrosOtroSeleccionado = value; }
+    public String getOtrosDemandado() { return otrosDemandado; }
+    public void setOtrosDemandado(String value) { this.otrosDemandado = value; }
+    public String getOtrosCuit() { return otrosCuit; }
+    public void setOtrosCuit(String value) { this.otrosCuit = value; }
+    public String getOtrosDomicilio() { return otrosDomicilio; }
+    public void setOtrosDomicilio(String value) { this.otrosDomicilio = value; }
+    public String getOtrosTerceroCitadoGarantia() { return otrosTerceroCitadoGarantia; }
+    public void setOtrosTerceroCitadoGarantia(String value) { this.otrosTerceroCitadoGarantia = value; }
+    public String getOtrosObservaciones() { return otrosObservaciones; }
+    public void setOtrosObservaciones(String value) { this.otrosObservaciones = value; }
 
 
     public boolean equals(Object object) {

--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -103,6 +103,7 @@ public class ExpedienteController implements Serializable {
     private static final String DDHH = "DDHH";
     private static final String LABORAL = "LABORAL";
     private static final String JURISDICCION_VOLUNTARIA = "JURISDICCIÓN VOLUNTARIA";
+    private static final String OTROS = "OTROS";
     private static final String JUSTICIA_PROVINCIAL = "JUSTICIA PROVINCIAL";
 
 
@@ -323,6 +324,25 @@ public class ExpedienteController implements Serializable {
 
     public boolean isExpedienteParaVerSeleccionadoJurisdiccionVoluntaria() {
         return isExpedienteJurisdiccionVoluntaria(selectedParaVerExp);
+    }
+
+    public boolean isExpedienteSeleccionadoOtrosJusticiaProvincial() {
+        return isExpedienteOtrosJusticiaProvincial(selected);
+    }
+
+    public boolean isExpedienteParaVerSeleccionadoOtrosJusticiaProvincial() {
+        return isExpedienteOtrosJusticiaProvincial(selectedParaVerExp);
+    }
+
+    public boolean isExpedienteSeleccionadoUsuarioSacConAbogados() {
+        return isExpedienteJurisdiccionVoluntaria(selected)
+                || isExpedienteOtrosJusticiaProvincial(selected);
+    }
+
+    private boolean isExpedienteOtrosJusticiaProvincial(Expediente expediente) {
+        return expediente != null
+                && equalsIgnoreCaseTrim(expediente.getEquipo(), JUSTICIA_PROVINCIAL)
+                && equalsIgnoreCaseTrim(expediente.getJpTipo(), OTROS);
     }
 
     private boolean isExpedienteJurisdiccionVoluntaria(Expediente expediente) {

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -139,7 +139,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
+                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">
@@ -233,6 +233,14 @@
                                             </ui:include>
                                         </h:panelGroup>
                                     </h:panelGroup>
+                                    <h:panelGroup id="otrosPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoOtrosJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/otrosEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
 
 <p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
 
@@ -282,8 +290,8 @@
                                     <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
                                     <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                         <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
-                                        <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
-                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                        <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
                                     </p:selectOneMenu>
 
                                     <p:outputLabel value="Expediente físico:" for="fisico" style="font-weight: bold" />

--- a/web/expediente/CreateExpJudicial.xhtml
+++ b/web/expediente/CreateExpJudicial.xhtml
@@ -98,7 +98,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
+                                    <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">
@@ -190,6 +190,14 @@
                                             </ui:include>
                                         </h:panelGroup>
                                     </h:panelGroup>
+                                    <h:panelGroup id="otrosPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoOtrosJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/otrosEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
 
 <p:outputLabel value="Equipo:" for="equipo" style="font-weight: bold" /><br></br>
 
@@ -260,8 +268,8 @@
                                         <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
                                         <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                             <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
-                                            <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
-                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                            <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
                                         </p:selectOneMenu>
                                     </h:panelGroup>
                             <br></br><br></br>

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -379,7 +379,7 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
+                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                     <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoDdhhJusticiaProvincial}">
@@ -474,6 +474,14 @@
                                             </ui:include>
                                         </h:panelGroup>
                                     </h:panelGroup>
+                                    <h:panelGroup id="otrosPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoOtrosJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/otrosEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
 
 <p:outputLabel value="Equipo:" for="equipo"  />
                                     <p:selectOneMenu id="equipo" editable="false" effect="fold" value="#{expedienteController.selected.equipo}">
@@ -514,8 +522,8 @@
                                     <p:outputLabel class="float-l" value="Usuario SAC:" for="usuarioSac" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}"/>
                                     <p:selectOneMenu id="usuarioSac" value="#{expedienteController.selected.usuarioSac}" rendered="#{expedienteController.expedienteSeleccionadoJudicialJusticiaProvincial}">
                                         <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
-                                        <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
-                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                        <f:selectItems value="#{empleadoController.abogados}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
+                                        <f:selectItems value="#{empleadoController.items}" var="empleado" itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}" rendered="#{not expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
                                     </p:selectOneMenu>
                                 </div>
                                 <div class="columna">

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -377,7 +377,7 @@
                                 <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                 <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                 <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel" />
+                                <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel" />
                                 </p:selectOneMenu>
 
                                 <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
@@ -464,6 +464,14 @@
                                         </ui:include>
                                     </h:panelGroup>
                                 </h:panelGroup>
+                                    <h:panelGroup id="otrosPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoOtrosJusticiaProvincial}">
+                                            <ui:include src="/expediente/fragments/otrosEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+
 
 <p:confirmDialog id="confirmdialog" widgetVar="confirm" global="true" showEffect="fade" hideEffect="fade" message="¿está seguro?" header="No es muy común cambiar el tipo de expediente:">
                                     <p:commandButton value="Si" type="button" styleClass="ui-confirmdialog-no" icon="pi pi-times" update=":ExpedienteJudicialEditForm:tabViewEditExpJudicialEditForm" />
@@ -589,10 +597,10 @@
                                     <f:selectItem itemLabel=" -- Elige un Usuario SAC --" noSelectionOption="true" />
                                     <f:selectItems value="#{empleadoController.abogados}" var="empleado"
                                                    itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"
-                                                   rendered="#{expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                                   rendered="#{expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
                                     <f:selectItems value="#{empleadoController.items}" var="empleado"
                                                    itemLabel="#{empleado.nombreyApellido}" itemValue="#{empleado.nombreyApellido}"
-                                                   rendered="#{not expedienteController.expedienteSeleccionadoJurisdiccionVoluntaria}" />
+                                                   rendered="#{not expedienteController.expedienteSeleccionadoUsuarioSacConAbogados}" />
                                 </p:selectOneMenu>
 
                             </div>

--- a/web/expediente/fragments/otrosEdit.xhtml
+++ b/web/expediente/fragments/otrosEdit.xhtml
@@ -1,0 +1,23 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui">
+    <div class="columna">
+        <p:outputLabel value="Tipo / clasificación" style="font-weight: bold" />
+        <p:selectBooleanCheckbox id="otrosDanosAccidente" value="#{expediente.otrosDanosAccidente}" itemLabel="Daños – Accidente" />
+        <p:selectBooleanCheckbox id="otrosDanosIncumplimiento" value="#{expediente.otrosDanosIncumplimientoContractualLeySeguros}" itemLabel="Daños – Incumplimiento contractual – Ley de Seguros" />
+        <p:selectBooleanCheckbox id="otrosDivorcio" value="#{expediente.otrosDivorcio}" itemLabel="Divorcio" />
+        <p:selectBooleanCheckbox id="otrosOtroSeleccionado" value="#{expediente.otrosOtroSeleccionado}" itemLabel="Otros" />
+    </div>
+    <div class="columna">
+        <p:outputLabel value="Demandado:" for="otrosDemandado" />
+        <p:inputText id="otrosDemandado" value="#{expediente.otrosDemandado}" />
+        <p:outputLabel value="CUIT:" for="otrosCuit" />
+        <p:inputText id="otrosCuit" value="#{expediente.otrosCuit}" />
+        <p:outputLabel value="Domicilio:" for="otrosDomicilio" />
+        <p:inputText id="otrosDomicilio" value="#{expediente.otrosDomicilio}" />
+        <p:outputLabel value="3ero citado en garantía:" for="otrosTerceroCitadoGarantia" />
+        <p:inputText id="otrosTerceroCitadoGarantia" value="#{expediente.otrosTerceroCitadoGarantia}" />
+        <p:outputLabel value="Observaciones:" for="otrosObservaciones" />
+        <p:inputTextarea id="otrosObservaciones" value="#{expediente.otrosObservaciones}" rows="7" cols="30" autoResize="false" />
+    </div>
+</ui:composition>


### PR DESCRIPTION
### Motivation

- Añadir soporte completo para el JP Tipo `OTROS` en Equipo = `JUSTICIA PROVINCIAL`, respetando el flujo Administrativo → Judicial y la arquitectura existente (LABORAL / JURISDICCIÓN VOLUNTARIA).  

### Description

- Persistencia: se agregaron nueve atributos nullable a la entidad `Expediente` para almacenar la clasificación y los datos administrativos de OTROS: `otrosDanosAccidente`, `otrosDanosIncumplimientoContractualLeySeguros`, `otrosDivorcio`, `otrosOtroSeleccionado`, `otrosDemandado`, `otrosCuit`, `otrosDomicilio`, `otrosTerceroCitadoGarantia`, `otrosObservaciones`, con getters/setters JPA correspondientes en `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java`.  
- Vistas / JSF: se creó el fragmento reutilizable `web/expediente/fragments/otrosEdit.xhtml` que implementa las dos columnas (clasificación booleanas y datos administrativos) y se integró este fragmento en las pantallas relevantes (`Create.xhtml`, `CreateExpJudicial.xhtml`, `Edit.xhtml`, `EditExpJudicial.xhtml`) bajo un panel condicional `otrosPanel` actualizable por AJAX; las inclusiones usan el mismo patrón que los fragments existentes.  
- Controller / lógica: se añadió la constante `OTROS` y métodos en `ExpedienteController` para detectar explícitamente `Equipo = JUSTICIA PROVINCIAL && jpTipo = OTROS` y para decidir cuándo el `Usuario SAC` debe usar la lista de `abogados`. La condición de administrativo/judicial sigue usando el campo existente `tipoDeExpediente` y los métodos de transformación (`updateConCambioParaJudicial` / `updateConCambioParaAdministrativo`) no fueron cambiados.  
- Reutilización de componentes: el desplegable `Usuario SAC` reutiliza `selected.usuarioSac` y la lista existente `empleadoController.abogados` (única fuente de abogados), sin crear nuevas listas, converters ni duplicar persistencia.  
- Script SQL de producción: se añadió `ALTER_TABLE_EXPEDIENTE_ADD_OTROS.sql` con `ALTER TABLE` que crea las columnas nuevas como `NULLABLE` y compatible con MySQL.  
- Archivos principales modificados/añadidos: `src/java/com/estudioAlvarezVersion2/jpa/Expediente.java`, `src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java`, `web/expediente/Create.xhtml`, `web/expediente/CreateExpJudicial.xhtml`, `web/expediente/Edit.xhtml`, `web/expediente/EditExpJudicial.xhtml`, `web/expediente/fragments/otrosEdit.xhtml`, `ALTER_TABLE_EXPEDIENTE_ADD_OTROS.sql`.

### Testing

- ✅ Verificación programática de integración (script): comprobé que cada nuevo campo JPA aparece en la entidad, en el script SQL y en el fragmento XHTML correspondiente (resultado: OK).  
- ✅ Validación XML/parseo de todos los `web/expediente` XHTML y fragments usando `xml.etree` para asegurar que las vistas son parseables (resultado: XML OK).  
- ✅ `git diff --check` y verificación del árbol de trabajo tras commit (resultado: OK, cambios commiteados).  
- ⚠️ Build/packaging con Ant (`ant clean jar`) no se pudo ejecutar en este entorno porque `ant` no está instalado (resultado: no ejecutado).  
- ⚠️ Tests en ejecución real (despliegue en servidor Java EE + base de datos): no se realizaron aquí; se requiere ejecutar en el entorno de despliegue con la base de datos (antes ejecutar el `ALTER TABLE` en producción).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a750a75dd5c8327af483a63a861a4b5)