### PR TITLE
Mostrar '3ero citado en garantía' sólo para opciones de Daños en otrosEdit.xhtml

### DIFF
--- a/web/expediente/fragments/otrosEdit.xhtml
+++ b/web/expediente/fragments/otrosEdit.xhtml
@@ -1,10 +1,15 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
                 xmlns:p="http://primefaces.org/ui">
     <div class="columna">
         <p:outputLabel value="Tipo / clasificación" style="font-weight: bold" />
-        <p:selectBooleanCheckbox id="otrosDanosAccidente" value="#{expediente.otrosDanosAccidente}" itemLabel="Daños – Accidente" />
-        <p:selectBooleanCheckbox id="otrosDanosIncumplimiento" value="#{expediente.otrosDanosIncumplimientoContractualLeySeguros}" itemLabel="Daños – Incumplimiento contractual – Ley de Seguros" />
+        <p:selectBooleanCheckbox id="otrosDanosAccidente" value="#{expediente.otrosDanosAccidente}" itemLabel="Daños – Accidente">
+            <p:ajax update="otrosTerceroCitadoGarantiaPanel" />
+        </p:selectBooleanCheckbox>
+        <p:selectBooleanCheckbox id="otrosDanosIncumplimiento" value="#{expediente.otrosDanosIncumplimientoContractualLeySeguros}" itemLabel="Daños – Incumplimiento contractual – Ley de Seguros">
+            <p:ajax update="otrosTerceroCitadoGarantiaPanel" />
+        </p:selectBooleanCheckbox>
         <p:selectBooleanCheckbox id="otrosDivorcio" value="#{expediente.otrosDivorcio}" itemLabel="Divorcio" />
         <p:selectBooleanCheckbox id="otrosOtroSeleccionado" value="#{expediente.otrosOtroSeleccionado}" itemLabel="Otros" />
     </div>
@@ -15,8 +20,13 @@
         <p:inputText id="otrosCuit" value="#{expediente.otrosCuit}" />
         <p:outputLabel value="Domicilio:" for="otrosDomicilio" />
         <p:inputText id="otrosDomicilio" value="#{expediente.otrosDomicilio}" />
-        <p:outputLabel value="3ero citado en garantía:" for="otrosTerceroCitadoGarantia" />
-        <p:inputText id="otrosTerceroCitadoGarantia" value="#{expediente.otrosTerceroCitadoGarantia}" />
+        <p:outputPanel id="otrosTerceroCitadoGarantiaPanel" layout="block">
+            <h:panelGroup layout="block"
+                          rendered="#{expediente.otrosDanosAccidente or expediente.otrosDanosIncumplimientoContractualLeySeguros}">
+                <p:outputLabel value="3ero citado en garantía:" for="otrosTerceroCitadoGarantia" />
+                <p:inputText id="otrosTerceroCitadoGarantia" value="#{expediente.otrosTerceroCitadoGarantia}" />
+            </h:panelGroup>
+        </p:outputPanel>
         <p:outputLabel value="Observaciones:" for="otrosObservaciones" />
         <p:inputTextarea id="otrosObservaciones" value="#{expediente.otrosObservaciones}" rows="7" cols="30" autoResize="false" />
     </div>


### PR DESCRIPTION
### Motivation

- Evitar que el campo "3ero citado en garantía" aparezca cuando se selecciona sólo "Divorcio" u "Otros", mostrando el campo únicamente para los tipos relacionados con daños.

### Description

- En `web/expediente/fragments/otrosEdit.xhtml` se añadió un `p:ajax` a las casillas `otrosDanosAccidente` y `otrosDanosIncumplimiento` para actualizar la visualización del panel correspondiente en cambios inmediatos. 
- Se envolvió el campo `otrosTerceroCitadoGarantia` dentro de un `p:outputPanel` y un `h:panelGroup` con `rendered="#{expediente.otrosDanosAccidente or expediente.otrosDanosIncumplimientoContractualLeySeguros}"` para que sólo se muestre cuando cualquiera de las dos opciones de daños esté seleccionada. 
- Se añadió la declaración de espacio de nombres `xmlns:h="http://xmlns.jcp.org/jsf/html"` requerida por el `h:panelGroup`.

### Testing

- Se validó el XML y la condición de visibilidad con una comprobación en Python (`ElementTree.parse`) y las aserciones sobre las cadenas esperadas, y la prueba pasó correctamente. 
- Se verificó que las dos entradas `update="otrosTerceroCitadoGarantiaPanel"` estén presentes mediante una comprobación automática y fue exitosa. 
- Las herramientas externas `xmllint` y `ant` no estaban disponibles en el entorno, por lo que la compilación completa no pudo ejecutarse aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75f9e651388327b538cc1be5bea579)