### PR TITLE
Agregar JP Tipo CONTENCIOSO ADMINISTRATIVO (Administrativo → Judicial)

### DIFF
--- a/ALTER_TABLE_EXPEDIENTE_ADD_CONTENCIOSO_ADMINISTRATIVO.sql
+++ b/ALTER_TABLE_EXPEDIENTE_ADD_CONTENCIOSO_ADMINISTRATIVO.sql
@@ -1,0 +1,10 @@
+ALTER TABLE Expediente
+    ADD COLUMN contenciosoPlenaJurisdiccion TINYINT(1) NULL,
+    ADD COLUMN contenciosoAmparo TINYINT(1) NULL,
+    ADD COLUMN contenciosoOtrosSeleccionado TINYINT(1) NULL,
+    ADD COLUMN contenciosoNumeroExpedienteAdministrativo VARCHAR(255) NULL,
+    ADD COLUMN contenciosoFechaInicioSolicitud DATE NULL,
+    ADD COLUMN contenciosoResolucion TEXT NULL,
+    ADD COLUMN contenciosoFechaResolucion DATE NULL,
+    ADD COLUMN contenciosoVencimientoDemanda DATE NULL,
+    ADD COLUMN contenciosoObservaciones TEXT NULL;

--- a/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
+++ b/src/java/com/estudioAlvarezVersion2/jpa/Expediente.java
@@ -438,6 +438,36 @@ public class Expediente implements Serializable {
     @Column(name = "otrosObservaciones")
     private String otrosObservaciones;
 
+    @Column(name = "contenciosoPlenaJurisdiccion")
+    private Boolean contenciosoPlenaJurisdiccion;
+
+    @Column(name = "contenciosoAmparo")
+    private Boolean contenciosoAmparo;
+
+    @Column(name = "contenciosoOtrosSeleccionado")
+    private Boolean contenciosoOtrosSeleccionado;
+
+    @Column(name = "contenciosoNumeroExpedienteAdministrativo")
+    private String contenciosoNumeroExpedienteAdministrativo;
+
+    @Column(name = "contenciosoFechaInicioSolicitud")
+    @Temporal(TemporalType.DATE)
+    private Date contenciosoFechaInicioSolicitud;
+
+    @Column(name = "contenciosoResolucion")
+    private String contenciosoResolucion;
+
+    @Column(name = "contenciosoFechaResolucion")
+    @Temporal(TemporalType.DATE)
+    private Date contenciosoFechaResolucion;
+
+    @Column(name = "contenciosoVencimientoDemanda")
+    @Temporal(TemporalType.DATE)
+    private Date contenciosoVencimientoDemanda;
+
+    @Column(name = "contenciosoObservaciones")
+    private String contenciosoObservaciones;
+
 
     public Expediente() {
     }
@@ -1297,6 +1327,25 @@ public class Expediente implements Serializable {
     public void setOtrosTerceroCitadoGarantia(String value) { this.otrosTerceroCitadoGarantia = value; }
     public String getOtrosObservaciones() { return otrosObservaciones; }
     public void setOtrosObservaciones(String value) { this.otrosObservaciones = value; }
+
+    public Boolean getContenciosoPlenaJurisdiccion() { return contenciosoPlenaJurisdiccion; }
+    public void setContenciosoPlenaJurisdiccion(Boolean value) { this.contenciosoPlenaJurisdiccion = value; }
+    public Boolean getContenciosoAmparo() { return contenciosoAmparo; }
+    public void setContenciosoAmparo(Boolean value) { this.contenciosoAmparo = value; }
+    public Boolean getContenciosoOtrosSeleccionado() { return contenciosoOtrosSeleccionado; }
+    public void setContenciosoOtrosSeleccionado(Boolean value) { this.contenciosoOtrosSeleccionado = value; }
+    public String getContenciosoNumeroExpedienteAdministrativo() { return contenciosoNumeroExpedienteAdministrativo; }
+    public void setContenciosoNumeroExpedienteAdministrativo(String value) { this.contenciosoNumeroExpedienteAdministrativo = value; }
+    public Date getContenciosoFechaInicioSolicitud() { return contenciosoFechaInicioSolicitud; }
+    public void setContenciosoFechaInicioSolicitud(Date value) { this.contenciosoFechaInicioSolicitud = value; }
+    public String getContenciosoResolucion() { return contenciosoResolucion; }
+    public void setContenciosoResolucion(String value) { this.contenciosoResolucion = value; }
+    public Date getContenciosoFechaResolucion() { return contenciosoFechaResolucion; }
+    public void setContenciosoFechaResolucion(Date value) { this.contenciosoFechaResolucion = value; }
+    public Date getContenciosoVencimientoDemanda() { return contenciosoVencimientoDemanda; }
+    public void setContenciosoVencimientoDemanda(Date value) { this.contenciosoVencimientoDemanda = value; }
+    public String getContenciosoObservaciones() { return contenciosoObservaciones; }
+    public void setContenciosoObservaciones(String value) { this.contenciosoObservaciones = value; }
 
 
     public boolean equals(Object object) {

--- a/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
+++ b/src/java/com/estudioAlvarezVersion2/jsf/ExpedienteController.java
@@ -104,6 +104,7 @@ public class ExpedienteController implements Serializable {
     private static final String LABORAL = "LABORAL";
     private static final String JURISDICCION_VOLUNTARIA = "JURISDICCIÓN VOLUNTARIA";
     private static final String OTROS = "OTROS";
+    private static final String CONTENCIOSO_ADMINISTRATIVO = "CONTENCIOSO ADMINISTRATIVO";
     private static final String JUSTICIA_PROVINCIAL = "JUSTICIA PROVINCIAL";
 
 
@@ -336,7 +337,18 @@ public class ExpedienteController implements Serializable {
 
     public boolean isExpedienteSeleccionadoUsuarioSacConAbogados() {
         return isExpedienteJurisdiccionVoluntaria(selected)
-                || isExpedienteOtrosJusticiaProvincial(selected);
+                || isExpedienteOtrosJusticiaProvincial(selected)
+                || isExpedienteContenciosoAdministrativo(selected);
+    }
+
+    public boolean isExpedienteSeleccionadoContenciosoAdministrativo() {
+        return isExpedienteContenciosoAdministrativo(selected);
+    }
+
+    private boolean isExpedienteContenciosoAdministrativo(Expediente expediente) {
+        return expediente != null
+                && equalsIgnoreCaseTrim(expediente.getEquipo(), JUSTICIA_PROVINCIAL)
+                && equalsIgnoreCaseTrim(expediente.getJpTipo(), CONTENCIOSO_ADMINISTRATIVO);
     }
 
     private boolean isExpedienteOtrosJusticiaProvincial(Expediente expediente) {

--- a/web/expediente/Create.xhtml
+++ b/web/expediente/Create.xhtml
@@ -139,7 +139,8 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel" />
+                                    <f:selectItem itemLabel="CONTENCIOSO ADMINISTRATIVO" itemValue="CONTENCIOSO ADMINISTRATIVO" />
+                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel contenciosoAdministrativoPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px; display: #{expedienteController.selected.jpTipo eq 'DDHH' ? 'block' : 'none'};">
                                         <div class="columna">
@@ -236,6 +237,13 @@
                                     <h:panelGroup id="otrosPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                         <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoOtrosJusticiaProvincial}">
                                             <ui:include src="/expediente/fragments/otrosEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                    <h:panelGroup id="contenciosoAdministrativoPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoContenciosoAdministrativo}">
+                                            <ui:include src="/expediente/fragments/contenciosoAdministrativoEdit.xhtml">
                                                 <ui:param name="expediente" value="#{expedienteController.selected}" />
                                             </ui:include>
                                         </h:panelGroup>

--- a/web/expediente/Edit.xhtml
+++ b/web/expediente/Edit.xhtml
@@ -379,7 +379,8 @@
                                     <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                     <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                     <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel" />
+                                    <f:selectItem itemLabel="CONTENCIOSO ADMINISTRATIVO" itemValue="CONTENCIOSO ADMINISTRATIVO" />
+                                    <p:ajax process="@this" update="ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel contenciosoAdministrativoPanel" />
                                     </p:selectOneMenu>
                                     <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                     <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoDdhhJusticiaProvincial}">
@@ -477,6 +478,13 @@
                                     <h:panelGroup id="otrosPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                         <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoOtrosJusticiaProvincial}">
                                             <ui:include src="/expediente/fragments/otrosEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                    <h:panelGroup id="contenciosoAdministrativoPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoContenciosoAdministrativo}">
+                                            <ui:include src="/expediente/fragments/contenciosoAdministrativoEdit.xhtml">
                                                 <ui:param name="expediente" value="#{expedienteController.selected}" />
                                             </ui:include>
                                         </h:panelGroup>

--- a/web/expediente/EditExpJudicial.xhtml
+++ b/web/expediente/EditExpJudicial.xhtml
@@ -377,7 +377,8 @@
                                 <f:selectItem itemLabel="LABORAL" itemValue="LABORAL" />
                                 <f:selectItem itemLabel="JURISDICCIÓN VOLUNTARIA" itemValue="JURISDICCIÓN VOLUNTARIA" />
                                 <f:selectItem itemLabel="OTROS" itemValue="OTROS" />
-                                <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel" />
+                                <f:selectItem itemLabel="CONTENCIOSO ADMINISTRATIVO" itemValue="CONTENCIOSO ADMINISTRATIVO" />
+                                <p:ajax process="@this" update="tipoDeExpedientePanel ddhhPanel laboralPanel jurisdiccionVoluntariaPanel otrosPanel contenciosoAdministrativoPanel" />
                                 </p:selectOneMenu>
 
                                 <h:panelGroup id="ddhhPanel" layout="block" style="width: 100%; margin-top: 15px;">
@@ -467,6 +468,13 @@
                                     <h:panelGroup id="otrosPanel" layout="block" style="width: 100%; margin-top: 15px;">
                                         <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoOtrosJusticiaProvincial}">
                                             <ui:include src="/expediente/fragments/otrosEdit.xhtml">
+                                                <ui:param name="expediente" value="#{expedienteController.selected}" />
+                                            </ui:include>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                    <h:panelGroup id="contenciosoAdministrativoPanel" layout="block" style="width: 100%; margin-top: 15px;">
+                                        <h:panelGroup layout="block" rendered="#{expedienteController.expedienteSeleccionadoContenciosoAdministrativo}">
+                                            <ui:include src="/expediente/fragments/contenciosoAdministrativoEdit.xhtml">
                                                 <ui:param name="expediente" value="#{expedienteController.selected}" />
                                             </ui:include>
                                         </h:panelGroup>

--- a/web/expediente/fragments/contenciosoAdministrativoEdit.xhtml
+++ b/web/expediente/fragments/contenciosoAdministrativoEdit.xhtml
@@ -1,0 +1,36 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui">
+    <div class="columna">
+        <p:outputLabel value="Tipo de contencioso administrativo" style="font-weight: bold" />
+        <p:selectBooleanCheckbox id="contenciosoPlenaJurisdiccion"
+                                 value="#{expediente.contenciosoPlenaJurisdiccion}"
+                                 itemLabel="Plena Jurisdicción" />
+        <p:selectBooleanCheckbox id="contenciosoAmparo"
+                                 value="#{expediente.contenciosoAmparo}"
+                                 itemLabel="Amparo" />
+        <p:selectBooleanCheckbox id="contenciosoOtrosSeleccionado"
+                                 value="#{expediente.contenciosoOtrosSeleccionado}"
+                                 itemLabel="Otros" />
+    </div>
+    <div class="columna">
+        <p:outputLabel value="N° de Expediente Administrativo:" for="contenciosoNumeroExpedienteAdministrativo" />
+        <p:inputText id="contenciosoNumeroExpedienteAdministrativo"
+                     value="#{expediente.contenciosoNumeroExpedienteAdministrativo}" />
+        <p:outputLabel value="Fecha inicio de solicitud:" for="contenciosoFechaInicioSolicitud" />
+        <p:calendar id="contenciosoFechaInicioSolicitud" pattern="dd/MM/yyyy"
+                    value="#{expediente.contenciosoFechaInicioSolicitud}" showOn="button" />
+        <p:outputLabel value="Resolución:" for="contenciosoResolucion" />
+        <p:inputTextarea id="contenciosoResolucion" value="#{expediente.contenciosoResolucion}"
+                         rows="3" cols="30" autoResize="false" />
+        <p:outputLabel value="Fecha de Resolución:" for="contenciosoFechaResolucion" />
+        <p:calendar id="contenciosoFechaResolucion" pattern="dd/MM/yyyy"
+                    value="#{expediente.contenciosoFechaResolucion}" showOn="button" />
+        <p:outputLabel value="Vto. para presentar demanda:" for="contenciosoVencimientoDemanda" />
+        <p:calendar id="contenciosoVencimientoDemanda" pattern="dd/MM/yyyy"
+                    value="#{expediente.contenciosoVencimientoDemanda}" showOn="button" />
+        <p:outputLabel value="Observaciones:" for="contenciosoObservaciones" />
+        <p:inputTextarea id="contenciosoObservaciones" value="#{expediente.contenciosoObservaciones}"
+                         rows="7" cols="30" autoResize="false" />
+    </div>
+</ui:composition>


### PR DESCRIPTION
### Motivation

- Implementar el nuevo JP Tipo `CONTENCIOSO ADMINISTRATIVO` bajo el equipo `JUSTICIA PROVINCIAL` respetando la arquitectura y flujo Administrativo → Judicial ya usado por otros JP Tipo (LABORAL, JURISDICCIÓN VOLUNTARIA, OTROS). 
- Reutilizar los componentes, predicados y el campo `usuarioSac` / la lista de abogados existentes sin duplicar lógica ni crear tablas o relaciones nuevas.

### Description

- Se añadieron campos JPA en `Expediente` para persistir la información administrativa: `contenciosoPlenaJurisdiccion` (Boolean), `contenciosoAmparo` (Boolean), `contenciosoOtrosSeleccionado` (Boolean), `contenciosoNumeroExpedienteAdministrativo` (String), `contenciosoFechaInicioSolicitud` (`Date` con `@Temporal(TemporalType.DATE)`), `contenciosoResolucion` (String), `contenciosoFechaResolucion` (`Date` con `@Temporal(TemporalType.DATE)`), `contenciosoVencimientoDemanda` (`Date` con `@Temporal(TemporalType.DATE)`) y `contenciosoObservaciones` (String).  
- Se agregó la constante y la lógica de detección positiva en `ExpedienteController` (`CONTENCIOSO_ADMINISTRATIVO` y `isExpedienteContenciosoAdministrativo`) y se incluyó al predicado que habilita el desplegable de `Usuario SAC` con la lista de abogados existente.  
- Se creó el fragmento reutilizable `web/expediente/fragments/contenciosoAdministrativoEdit.xhtml` que contiene la Columna 1 (checkboxes) y Columna 2 (campos administrativos y `p:calendar` con `pattern="dd/MM/yyyy"`) y se integró en `Create.xhtml`, `Edit.xhtml` y `EditExpJudicial.xhtml` activándolo por AJAX cuando `jpTipo == 'CONTENCIOSO ADMINISTRATIVO'`.  
- Se añadió el script SQL exacto `ALTER_TABLE_EXPEDIENTE_ADD_CONTENCIOSO_ADMINISTRATIVO.sql` con columnas `NULL`-ables y tipos apropiados (`TINYINT(1)`, `VARCHAR(255)`, `DATE`, `TEXT`) para aplicar en producción sin afectar expedientes históricos.

### Testing

- Parseo XML de los `xhtml` modificados con `xml.etree.ElementTree.parse(...)` y verificación de bindings, y una comprobación automática de la existencia de getters/setters para los nuevos accesores; ambos pasos completaron correctamente. 
- Construcción del proyecto con Ant (`ant -q clean jar`) realizada en el entorno y finalizada sin errores de compilación. 
- Verificaciones automáticas de estilo/consistencia: `git diff --check`, `rg`/scripts que confirmaron inclusiones en `Create/Edit/EditExpJudicial.xhtml` y presencia de las nuevas constantes y métodos en el controller, sin advertencias pendientes. 
- Recomendación de pruebas manuales (no automatizadas aquí): ejecutar la migración SQL en staging, probar el ciclo completo (crear administrativo, guardar, reabrir, judicializar, comprobar que los datos administrativos persisten y que el `Usuario SAC` usa la lista de abogados existente) y validar escenarios históricos para evitar NullPointer/JSF/JPA en runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75fee8d8308327bdb75fc0759b52c8)